### PR TITLE
(GEP-608) Move "Puppet Project Nature" toggle to "Configure" menu

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.ui/plugin.xml
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/plugin.xml
@@ -354,6 +354,34 @@
 				</visibleWhen>
 			</command>
 		</menuContribution>
+		<menuContribution locationURI="popup:org.eclipse.ui.projectConfigure">
+			<command commandId="com.puppetlabs.geppetto.pp.dsl.ui.addRemoveNatureAction" style="push" label="Remove Puppet Nature">
+				<visibleWhen checkEnabled="false">
+					<with variable="selection">
+						<count value="1"/>
+						<iterate>
+							<adapt type="org.eclipse.core.resources.IProject">
+								<test value="com.puppetlabs.geppetto.pp.dsl.ui.puppetNature" property="org.eclipse.core.resources.projectNature"/>
+							</adapt>
+						</iterate>
+					</with>
+				</visibleWhen>
+			</command>
+			<command commandId="com.puppetlabs.geppetto.pp.dsl.ui.addRemoveNatureAction" style="push" label="Add Puppet Nature">
+				<visibleWhen checkEnabled="false">
+					<with variable="selection">
+						<count value="1"/>
+						<iterate>
+							<adapt type="org.eclipse.core.resources.IProject">
+								<not>
+									<test value="com.puppetlabs.geppetto.pp.dsl.ui.puppetNature" property="org.eclipse.core.resources.projectNature"/>
+								</not>
+							</adapt>
+						</iterate>
+					</with>
+				</visibleWhen>
+			</command>
+		</menuContribution>
 	</extension>
    <!-- quickfix marker resolution generator -->
    <extension
@@ -402,6 +430,15 @@
           </run>
        </runtime>
     </extension>
+   <extension
+         point="org.eclipse.ui.commands">
+      <command
+            name="Add/Remove Puppet Nature"
+            defaultHandler="com.puppetlabs.geppetto.pp.dsl.ui.builder.ToggleNatureAction"
+            categoryId="org.eclipse.ui.category.project"
+            id="com.puppetlabs.geppetto.pp.dsl.ui.addRemoveNatureAction">
+      </command>
+   </extension>
     <extension
           point="org.eclipse.xtext.extension_resourceServiceProvider">
        <resourceServiceProvider

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/builder/NatureAddingEditorCallback.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/builder/NatureAddingEditorCallback.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Puppet Labs
  */
@@ -24,7 +24,7 @@ public class NatureAddingEditorCallback extends ValidatingEditorCallback {
 		IResource resource = editor.getResource();
 		if(resource != null && resource.getProject().isAccessible() && !resource.getProject().isHidden() &&
 				!ToggleNatureAction.hasNature(resource.getProject())) {
-			ToggleNatureAction.toggleNature(resource.getProject(), true);
+			ToggleNatureAction.toggleNature(resource.getProject());
 		}
 	}
 


### PR DESCRIPTION
This PR ensures that:
- the deprecated 'popupMenu' construct is replaced with a menu contribution and commands
- the menu item ends up under the 'Configure' menu together with the corresponding command to
  add or remove the xtext nature.
