### PR TITLE
(GEP-24) Save action with format corrupts file

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/linked/ExtLinkedXtextEditor.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/linked/ExtLinkedXtextEditor.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Puppet Labs
  */
@@ -13,7 +13,6 @@ package com.puppetlabs.geppetto.pp.dsl.ui.linked;
 
 import java.io.File;
 
-import com.puppetlabs.geppetto.pp.dsl.ui.preferences.data.FormatterGeneralPreferences;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.URIUtil;
@@ -54,20 +53,21 @@ import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.outline.impl.OutlinePage;
 
 import com.google.inject.Inject;
+import com.puppetlabs.geppetto.pp.dsl.ui.preferences.data.FormatterGeneralPreferences;
 
 /**
  * This class extends the standard XtextEditor to make it capable of
  * opening and saving external files by managing them as linked resources.
- * 
+ *
  * This implementation also supports temporary files than when saved will change to
  * a SaveAs operation (also see {@link TmpFileStoreEditorInput}).
- * 
+ *
  * An editor customizer can also be bound and it will receive calls to manage the content
  * of the context menu (see {@link IExtXtextEditorCustomizer}).
- * 
+ *
  * Also see {@link ExtLinkedXtextEditorMatchingStrategy} which is required to ensure multiple
  * editors are not opened for the same file.
- * 
+ *
  */
 public class ExtLinkedXtextEditor extends XtextEditor {
 
@@ -136,7 +136,7 @@ public class ExtLinkedXtextEditor extends XtextEditor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.xtext.ui.editor.XtextEditor#doSave(org.eclipse.core.runtime.IProgressMonitor)
 	 */
 	@Override
@@ -164,19 +164,19 @@ public class ExtLinkedXtextEditor extends XtextEditor {
 			}
 		}
 		rememberSelection();
-		saveActions.perform(getResource(), getDocument());
+		saveActions.perform(getSourceViewerConfiguration(), getSourceViewer(), getResource(), getDocument());
 		restoreSelection();
 		super.doSave(progressMonitor);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.xtext.ui.editor.XtextEditor#doSaveAs()
 	 */
 	@Override
 	public void doSaveAs() {
-		saveActions.perform(getResource(), getDocument());
+		saveActions.perform(getSourceViewerConfiguration(), getSourceViewer(), getResource(), getDocument());
 		super.doSaveAs();
 		// make sure the outline is fully refreshed
 		IContentOutlinePage outlinePage = (IContentOutlinePage) getAdapter(IContentOutlinePage.class);
@@ -186,8 +186,8 @@ public class ExtLinkedXtextEditor extends XtextEditor {
 
 	/**
 	 * Allows customization of the editor title.
-	 * 
-	 * 
+	 *
+	 *
 	 * @see org.eclipse.xtext.ui.editor.XtextEditor#doSetInput(org.eclipse.ui.IEditorInput)
 	 */
 	@Override
@@ -206,7 +206,7 @@ public class ExtLinkedXtextEditor extends XtextEditor {
 
 	/**
 	 * Overridden to allow customization of editor context menu via injected handler
-	 * 
+	 *
 	 * @see org.eclipse.ui.editors.text.TextEditor#editorContextMenuAboutToShow(org.eclipse.jface.action.IMenuManager)
 	 */
 	@Override
@@ -321,7 +321,7 @@ public class ExtLinkedXtextEditor extends XtextEditor {
 
 	/*
 	 * @see org.eclipse.ui.texteditor.AbstractTextEditor#isTabConversionEnabled()
-	 * 
+	 *
 	 * @since 3.3
 	 */
 	@Override

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/linked/ISaveActions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/linked/ISaveActions.java
@@ -4,19 +4,22 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Puppet Labs
  */
 package com.puppetlabs.geppetto.pp.dsl.ui.linked;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.SourceViewerConfiguration;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 
 /**
  * Interface for performing save actions.
- * 
+ *
  */
 public interface ISaveActions {
-	public void perform(IResource r, IXtextDocument document);
+	public void perform(SourceViewerConfiguration sourceViewerConfiguration, ISourceViewer sourceViewer, IResource r,
+			IXtextDocument document);
 }

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/xtext/dommodel/impl/CompositeDomNode.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/xtext/dommodel/impl/CompositeDomNode.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Puppet Labs
  */
@@ -14,15 +14,14 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.puppetlabs.xtext.dommodel.DomModelUtils;
 import com.puppetlabs.xtext.dommodel.IDomNode;
 
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-
 /**
  * A default implementation of IDomNode that has the capacity to hold AbstractDomNode children.
- * 
+ *
  */
 public class CompositeDomNode extends BaseDomNode {
 	// public class ListBidiIterator extends UnmodifiableIterator<IDomNode> implements BidiIterator<IDomNode> {
@@ -136,7 +135,7 @@ public class CompositeDomNode extends BaseDomNode {
 			if(DomModelUtils.isWhitespace(d))
 				whitespaceCount++;
 			if(DomModelUtils.isComment(d))
-				whitespaceCount++;
+				commentCount++;
 		}
 		setLength(length);
 		int childCount = children.size();
@@ -177,7 +176,7 @@ public class CompositeDomNode extends BaseDomNode {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see com.puppetlabs.geppetto.pp.dsl.xt.dommodel.impl.AbstractDomNode#hasChildren()
 	 */
 	@Override
@@ -187,7 +186,7 @@ public class CompositeDomNode extends BaseDomNode {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see com.puppetlabs.geppetto.pp.dsl.xt.dommodel.impl.AbstractDomNode#isLeaf()
 	 */
 	@Override


### PR DESCRIPTION
The save action may be configured to both modify the document
by removing trailing spaces and then do a full format.

The save actions were correctly applied to the document inside
a document modify operation but bad things happened when the
format operation was called inside that same operation. The
formatter then attemtped to format the original XtextResource (which
hadn't been altered) yet using the lenght of the modified document
with loss of characters at the end as the result.

This commit ensures that the save actions are committed to the
resource before the formatter kicks in. It also optimizes (per
suggestion in a TODO comment) so that the formatting is performed
using the configured IContentFormatterFactory.
