### PR TITLE
(GEP-165) Speed up the CSS Dom formatter

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/xtext/dommodel/IDomNode.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/xtext/dommodel/IDomNode.java
@@ -4,32 +4,31 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   itemis AG (http://www.itemis.eu) - intial API
  *   Puppet Labs - intial API and implementation
- *   
- * 
+ *
+ *
  */
 package com.puppetlabs.xtext.dommodel;
 
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import com.puppetlabs.xtext.dommodel.formatter.css.StyleSet;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.nodemodel.INode;
 
 import com.google.common.collect.Sets;
+import com.puppetlabs.xtext.dommodel.formatter.css.StyleSet;
 
 /**
  * A node in a document model.
  * TODO: Should probably be capable of providing diagnostics/errors since formatting is often not wanted / required
  * to be verbatim.
- * 
+ *
  */
 public interface IDomNode {
 	/**
@@ -176,12 +175,12 @@ public interface IDomNode {
 		 */
 		public static final int numberOfValues = 8;
 
-		public static final Set<NodeType> whitespaceSet = Collections.unmodifiableSet(EnumSet.of(WHITESPACE));
+		public static final Set<NodeType> whitespaceSet = EnumSet.of(WHITESPACE);
 
 		// All bits set except for whitepsace
-		public static final Set<NodeType> nonWhitespaceSet = Collections.unmodifiableSet(Sets.complementOf(EnumSet.of(NodeType.WHITESPACE)));
+		public static final Set<NodeType> nonWhitespaceSet = Sets.complementOf(EnumSet.of(NodeType.WHITESPACE));
 
-		public static final Set<NodeType> anySet = Collections.unmodifiableSet(EnumSet.allOf(NodeType.class));
+		public static final Set<NodeType> anySet = EnumSet.allOf(NodeType.class);
 
 	}
 
@@ -191,7 +190,7 @@ public interface IDomNode {
 	/**
 	 * Returns the children of a composite node, or an empty list if the node is a leaf, or a composite with no
 	 * children.
-	 * 
+	 *
 	 * @return a list of this node's children (or an empty list)
 	 */
 	public List<IDomNode> getChildren();
@@ -199,10 +198,10 @@ public interface IDomNode {
 	/**
 	 * NOTE: If there a nodes in the DOM that represents layout structure e.g. table/columns it is not possible to
 	 * provide a grammarElement for the Table or Row. Return null for those as well - or move to a sub interface.
-	 * 
+	 *
 	 * Returns the grammar element that created this node. May return <code>null</code> in case of unrecoverable syntax
 	 * errors. This happens usually when a keyword occurred at an unexpected offset.
-	 * 
+	 *
 	 * @return the grammar element that created this node. May return <code>null</code>.
 	 */
 	public EObject getGrammarElement();
@@ -212,10 +211,10 @@ public interface IDomNode {
 	 * the length of a table? The length of rows and columns may be affected by layout.
 	 * NOTE: the INode reports length excluding hidden tokens - confused over the difference / getText, getTotalLength
 	 * etc. Should the DOM behave the same way.
-	 * 
+	 *
 	 * Returns the length of this node excluding hidden tokens. If this node is a hidden leaf node, the
 	 * total length is returned.
-	 * 
+	 *
 	 * @return the length of this node excluding hidden tokens.
 	 */
 	public int getLength();
@@ -224,14 +223,15 @@ public interface IDomNode {
 	 * Returns the nearest semantic object that is associated with the (sub) tree rooted in this node.
 	 * May return <code>null</code> for situation like when a parser refused to create any objects due to
 	 * unrecoverable errors.
-	 * 
-	 * @return the nearest semantic object that is associated with the (sub) tree rooted in this node. May return <code>null</code>.
+	 *
+	 * @return the nearest semantic object that is associated with the (sub) tree rooted in this node. May return
+	 *         <code>null</code>.
 	 */
 	public EObject getNearestSemanticObject();
 
 	/**
 	 * Returns the next sibling of this node, or null, if this is the last sibling in a composite node.
-	 * 
+	 *
 	 * @return
 	 */
 	public IDomNode getNextSibling();
@@ -239,7 +239,7 @@ public interface IDomNode {
 	/**
 	 * Returns the INode that covers the same text as this IDomNode. May return <code>null</null> if there is
 	 * no such node.
-	 * 
+	 *
 	 * @return the INode that covers the same logical text sequence as this IDomNode. May return <code>null</code>
 	 */
 	public INode getNode();
@@ -247,14 +247,14 @@ public interface IDomNode {
 	/**
 	 * Returns a node identifier which may be used in selection rules. May return null (in which case selection
 	 * on identity is not possible).
-	 * 
+	 *
 	 * @return the user assigned identity of the node.
 	 */
 	public Object getNodeId();
 
 	/**
 	 * Returns the {@link NodeType} of this dom node.
-	 * 
+	 *
 	 * @return
 	 */
 	public NodeType getNodeType();
@@ -263,21 +263,21 @@ public interface IDomNode {
 	 * Returns the offset of this node excluding hidden tokens. If this node is a hidden leaf node or
 	 * a composite node that does only contain hidden leaf nodes, the
 	 * total offset is returned.
-	 * 
+	 *
 	 * @return the offset of this node excluding hidden tokens.
 	 */
 	int getOffset();
 
 	/**
 	 * Returns the parent of the node or <code>null</code> if and only if this is the root node.
-	 * 
+	 *
 	 * @return the parent of this node or <code>null</code>.
 	 */
 	public IDomNode getParent();
 
 	/**
 	 * Returns the node being the previous node among this node's parent's children.
-	 * 
+	 *
 	 * @return the previous sibling, or null if this node is the first child (or not a child at all).
 	 */
 	public IDomNode getPreviousSibling();
@@ -285,7 +285,7 @@ public interface IDomNode {
 	/**
 	 * Returns the semantic object associated with the (sub) tree rooted in this node, or null if
 	 * no semantic object is directly associated with this node. Also see {@link #getNearestSemanticObject()}.
-	 * 
+	 *
 	 * @return the direct semantic object, or null
 	 */
 	public EObject getSemanticObject();
@@ -298,14 +298,15 @@ public interface IDomNode {
 	/**
 	 * A DomNode may have an associated StyleSet; styles applicable only to this node that match with the
 	 * highest specificity.
-	 * 
+	 *
 	 * @return
 	 */
 	public StyleSet getStyles();
 
 	/**
-	 * Returns the text that is covered by this node (including hidden tokens). The result is never <code>null</code> but may be empty.
-	 * 
+	 * Returns the text that is covered by this node (including hidden tokens). The result is never <code>null</code>
+	 * but may be empty.
+	 *
 	 * @return the text that is covered by this node (including hidden tokens). Never <code>null</code>.
 	 */
 	String getText();
@@ -313,21 +314,21 @@ public interface IDomNode {
 	/**
 	 * Returns <code>true</code> if this node has any children. A node may have no children - this does not
 	 * make it a leaf node ({@link #isLeaf()}.
-	 * 
+	 *
 	 * @return <code>true</code> if this node has any children.
 	 */
 	public boolean hasChildren();
 
 	/**
 	 * Nodes are either Leaf nodes, or composite nodes (that may have children).
-	 * 
+	 *
 	 * @return true if node is a leaf node
 	 */
 	public boolean isLeaf();
 
 	/**
 	 * Returns an iterator over this nodes parents, starting with the immediate parent.
-	 * 
+	 *
 	 * @return
 	 */
 	public Iterator<IDomNode> parents();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/xtext/dommodel/formatter/css/Select.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/xtext/dommodel/formatter/css/Select.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Puppet Labs
  */
@@ -15,25 +15,25 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.puppetlabs.xtext.dommodel.DomModelUtils;
-import com.puppetlabs.xtext.dommodel.IDomNode;
-import com.puppetlabs.xtext.dommodel.IDomNode.NodeType;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
+import com.puppetlabs.xtext.dommodel.DomModelUtils;
+import com.puppetlabs.xtext.dommodel.IDomNode;
+import com.puppetlabs.xtext.dommodel.IDomNode.NodeType;
 
 /**
  * Style Select is used to produce a configured Selector.
- * 
+ *
  */
 public class Select {
 
 	/**
 	 * A compound rule, where all rules must be satisfied.
-	 * 
+	 *
 	 */
 	public static class And extends Selector {
 		private int specificity = 0;
@@ -104,7 +104,7 @@ public class Select {
 
 		/**
 		 * Selectors for containers - the nearest container first
-		 * 
+		 *
 		 * @param selectors
 		 */
 		public Containment(Selector... selectors) {
@@ -172,7 +172,8 @@ public class Select {
 	}
 
 	/**
-	 * A selector that is useful when debugging matching (wrap a real selector and set a breakpoint in {@link #matches(IDomNode)}.
+	 * A selector that is useful when debugging matching (wrap a real selector and set a breakpoint in
+	 * {@link #matches(IDomNode)}.
 	 */
 	public static class DebugSelector extends Selector {
 		private Selector wrappedSelector;
@@ -256,7 +257,7 @@ public class Select {
 	/**
 	 * The next to most specific selector that matches anything.
 	 * Should be combined with And selector to make the and specificity very high.
-	 * 
+	 *
 	 */
 	public static class Important extends Selector {
 
@@ -286,7 +287,7 @@ public class Select {
 
 	/**
 	 * The most specific selector that matches on a instance using ==.
-	 * 
+	 *
 	 */
 	public static class Instance extends Selector {
 		private final IDomNode node;
@@ -326,7 +327,7 @@ public class Select {
 
 	/**
 	 * Matches IDomNodes on NodeType, style classifier, and id.
-	 * 
+	 *
 	 */
 	public static class NodeSelector extends Selector {
 
@@ -349,7 +350,7 @@ public class Select {
 
 		/**
 		 * Node must have all the given style classifiers.
-		 * 
+		 *
 		 * @param styleClasses
 		 */
 		public NodeSelector(Collection<Object> styleClasses) {
@@ -358,7 +359,7 @@ public class Select {
 
 		/**
 		 * Node must have all of the given style classifiers and the given id.
-		 * 
+		 *
 		 * @param styleClasses
 		 * @param id
 		 */
@@ -368,7 +369,7 @@ public class Select {
 
 		/**
 		 * Node must have the given node type
-		 * 
+		 *
 		 * @param t
 		 */
 		public NodeSelector(NodeType t) {
@@ -377,7 +378,7 @@ public class Select {
 
 		/**
 		 * Node must have the given node type and all of the given style classifiers.
-		 * 
+		 *
 		 * @param nodeType
 		 * @param styleClasses
 		 */
@@ -387,7 +388,7 @@ public class Select {
 
 		/**
 		 * Node must have the given node type, and all of the give style classifiers and the given id.
-		 * 
+		 *
 		 * @param nodeType
 		 * @param styleClasses
 		 * @param id
@@ -399,7 +400,7 @@ public class Select {
 		/**
 		 * Node must have the given node type, and the given style classifier
 		 * (may have other style classes assigned), and the given id).
-		 * 
+		 *
 		 * @param nodeType
 		 * @param styleClass
 		 * @param id
@@ -410,7 +411,7 @@ public class Select {
 
 		/**
 		 * Node must have all the given node statuses (may have other node status set).
-		 * 
+		 *
 		 * @param nodeTypes
 		 */
 		public NodeSelector(Set<NodeType> nodeTypes) {
@@ -419,7 +420,7 @@ public class Select {
 
 		/**
 		 * Node must have the given node statuses (may have other status set), and all of the given style classes.
-		 * 
+		 *
 		 * @param nodeTypes
 		 * @param styleClasses
 		 */
@@ -430,7 +431,7 @@ public class Select {
 		/**
 		 * Node must have all the given node statuses (may have other status set), and all of the given style classes
 		 * and the given id.
-		 * 
+		 *
 		 * @param nodeTypes
 		 *            - may be null (any type)
 		 * @param styleClass
@@ -457,11 +458,13 @@ public class Select {
 			if(!(selector instanceof NodeSelector))
 				return false;
 			NodeSelector e = (NodeSelector) selector;
+			if(!matchingId.equals(e.matchingId))
+				return false;
+			if(matchingClassifiers.size() != e.matchingClassifiers.size())
+				return false;
 			if(!matchingNodeTypes.equals(e.matchingNodeTypes))
 				return false;
-			if(!(matchingClassifiers.size() == e.matchingClassifiers.size() && e.matchingClassifiers.containsAll(matchingClassifiers)))
-				return false;
-			if(!matchingId.equals(e.matchingId))
+			if(!e.matchingClassifiers.containsAll(matchingClassifiers))
 				return false;
 			return true;
 		}
@@ -500,14 +503,16 @@ public class Select {
 			if(node == null)
 				return false;
 
+			if(matchingId != NoIdMatch && !matchingId.equals(node.getNodeId()))
+				return false;
+
 			if(!matchingNodeTypes.contains(node.getNodeType()))
 				return false;
 
 			// i.e styleClass && styleClass && ...
 			if(matchingClassifiers.size() > 0 && !node.getStyleClassifiers().containsAll(matchingClassifiers))
 				return false;
-			if(matchingId != NoIdMatch && !matchingId.equals(node.getNodeId()))
-				return false;
+
 			return true;
 		}
 
@@ -538,7 +543,7 @@ public class Select {
 	 * Negates a selector and increases the specificity by one.
 	 * e.g. selection of not(a) is more important than selection of just a.
 	 * Not does not select a null node.
-	 * 
+	 *
 	 */
 	public static class Not extends Selector {
 		private Selector selector;
@@ -580,7 +585,7 @@ public class Select {
 
 	/**
 	 * A NullSelector is only useful in a NullRule. It matches nothing.
-	 * 
+	 *
 	 */
 	public static class NullSelector extends Selector {
 
@@ -607,7 +612,7 @@ public class Select {
 
 	/**
 	 * Applies the delegate selector to the parent of the node being matched.
-	 * 
+	 *
 	 */
 	public static class ParentSelector extends Selector {
 		private Selector parentSelector;
@@ -713,7 +718,7 @@ public class Select {
 		/**
 		 * Returns the specificity in the same style as used in CSS:
 		 * 100 * id count + 10 * class count + 1 * other count
-		 * 
+		 *
 		 * @return
 		 */
 		public abstract int getSpecificity();
@@ -735,7 +740,7 @@ public class Select {
 
 	/**
 	 * A Selector matching on semantic information
-	 * 
+	 *
 	 */
 	public static class SemanticSelector extends Selector {
 		private EClass eClass;
@@ -798,7 +803,7 @@ public class Select {
 
 	/**
 	 * Applies the delegate selector to the successor of the matching node.
-	 * 
+	 *
 	 */
 	public static class SuccessorSelector extends Selector {
 		private Selector successorSelector;
@@ -838,7 +843,7 @@ public class Select {
 
 	/**
 	 * Selects matching text.
-	 * 
+	 *
 	 */
 	public static class Text extends Selector {
 		private final String text;
@@ -881,7 +886,7 @@ public class Select {
 	/**
 	 * Selects a node that is matched by the given nodeSelector if the node's predecessor matches
 	 * the given predecessor selector.
-	 * 
+	 *
 	 * @param nodeSelector
 	 * @param predecessor
 	 * @return
@@ -909,7 +914,7 @@ public class Select {
 	/**
 	 * Selects a node matching the given nodeSelector, if this node is before a node matching the
 	 * given successor selector.
-	 * 
+	 *
 	 * @param nodeSelector
 	 * @param successor
 	 * @return
@@ -970,7 +975,7 @@ public class Select {
 
 	/**
 	 * Select node with a nearest semantic object with given clazz, or a supertype of given clazz.
-	 * 
+	 *
 	 * @param clazz
 	 * @return
 	 */
@@ -980,7 +985,7 @@ public class Select {
 
 	/**
 	 * Select node with a nearest semantic object being an instance of the given clazz.
-	 * 
+	 *
 	 * @param clazz
 	 * @return
 	 */
@@ -1034,7 +1039,7 @@ public class Select {
 
 	/**
 	 * Select node with a direct semantic object with given clazz, or a supertype of given clazz.
-	 * 
+	 *
 	 * @param clazz
 	 * @return
 	 */
@@ -1044,7 +1049,7 @@ public class Select {
 
 	/**
 	 * Select node with a direct semantic object with given clazz.
-	 * 
+	 *
 	 * @param clazz
 	 * @return
 	 */


### PR DESCRIPTION
Formatting large files is a fairly slow process. On older laptops
it can take several seconds to format a moderately large manifest.
Profiling shows that the culprit is in Select.NodeSelector.match().

This commit will speed things up a lot. The main reason for the
speed-up is that the constant predefined EnumSet instances are no
longer wrapped in a Collections.unmodifiableSet() since that
wrapper effectively removes all benefits of using EnumSets. The
underlying cause can be found in the RegularEnumSet and the
first two lines of the containsAll() method:

```
 public boolean containsAll(Collection<?> c) {
    if (!(c instanceof RegularEnumSet))
        return super.containsAll(c);
```

Wrapping the EnumSet will result in super.containsAll(c) which in
turn will do a sequential iteration over the elements and call the
contains() method on each. The contains() method in turn will check
the class of the element befor checking if the element bitmap overlaps.

Compare this to just comparing the 'elementType' contained in both
sets once and then checking for bitmap overlap.
