### PR TITLE
(GEP-166) Remove project specific Module preferences

### DIFF
--- a/com.puppetlabs.geppetto.module.dsl.ui/plugin.xml
+++ b/com.puppetlabs.geppetto.module.dsl.ui/plugin.xml
@@ -117,42 +117,6 @@
         </page>
     </extension>
     <extension
-            point="org.eclipse.ui.propertyPages">
-        <page
-              category="com.puppetlabs.geppetto.puppet.ui"
-              class="com.puppetlabs.geppetto.module.dsl.ui.ModuleExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
-              id="com.puppetlabs.geppetto.module.dsl.Module"
-              name="Module">
-            <keywordReference id="com.puppetlabs.geppetto.module.dsl.ui.keyword_Module"/>
-            <enabledWhen>
-	            <adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-	        <filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-        </page>
-        <page
-              category="com.puppetlabs.geppetto.module.dsl.Module"
-              class="com.puppetlabs.geppetto.module.dsl.ui.ModuleExecutableExtensionFactory:com.puppetlabs.geppetto.module.dsl.ui.preferences.ForgePreferencesPage"
-              id="com.puppetlabs.geppetto.module.dsl.Module.forge"
-              name="Puppet Forge">
-            <keywordReference id="com.puppetlabs.geppetto.module.dsl.ui.keyword_Module"/>
-            <enabledWhen>
-	            <adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-	        <filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-        </page>
-        <page
-              category="com.puppetlabs.geppetto.module.dsl.Module"
-              class="com.puppetlabs.geppetto.module.dsl.ui.ModuleExecutableExtensionFactory:com.puppetlabs.geppetto.module.dsl.ui.preferences.PotentialModuleProblemPreferencesPage"
-              id="com.puppetlabs.geppetto.module.dsl.Module.pproblem"
-              name="Potential Problems">
-            <keywordReference id="com.puppetlabs.geppetto.module.dsl.ui.keyword_Module"/>
-            <enabledWhen>
-	            <adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-	        <filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-        </page>
-    </extension>
-    <extension
         point="org.eclipse.ui.keywords">
         <keyword
             id="com.puppetlabs.geppetto.module.dsl.ui.keyword_Module"


### PR DESCRIPTION
This commit removes the "Puppet Forge" page and "Potential Problems"
page along with their parent "Module" page from the project specific
preferences. They were never intended to be present there and adding
them was a mistake. Changing them has no effect since no code will
check their settings.
