### PR TITLE
(GEP-604) Allow references to preceding definition arguments

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
@@ -225,14 +225,8 @@ public class PPResourceLinker implements IPPDiagnostics {
 
 	private void _link(HostClassDefinition o, PPImportedNamesAdapter importedNames, IMessageAcceptor acceptor) {
 		final LiteralExpression parent = o.getParent();
-		if(parent == null)
-			return;
-		String parentString = null;
-		if(parent.eClass() == PPPackage.Literals.LITERAL_DEFAULT)
-			parentString = "default";
-		else if(parent.eClass() == PPPackage.Literals.LITERAL_NAME_OR_REFERENCE)
-			parentString = ((LiteralNameOrReference) parent).getValue();
-		if(parentString == null || parentString.length() < 1)
+		String parentString = PPFinder.getNameString(parent);
+		if(parentString == null)
 			return;
 
 		SearchResult searchResult = ppFinder.findHostClasses(o, parentString, importedNames);


### PR DESCRIPTION
This pull request consists of two commits:
1. Ensures that expressions in a definition argument list are allowed to reference arguments that has been declared previously in the list and that references to other arguments in the list are reported as "Reference to not yet initialized variable" rather than "Unqualified and Unknown variable".
2. Ensures that the variables that are inherited can be referenced by the parameter default expressions.
