### PR TITLE
(GEP-157) Replace hardcoded attribute cluster size with preference

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/formatting/PPSemanticLayout.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/formatting/PPSemanticLayout.java
@@ -166,8 +166,6 @@ public class PPSemanticLayout extends DeclarativeSemanticFlowLayout {
 		PPPackage.UNLESS_EXPRESSION, PPPackage.NODE_DEFINITION, PPPackage.RESOURCE_EXPRESSION,
 		PPPackage.SELECTOR_EXPRESSION };
 
-	private static final int ATTRIBUTE_OPERATIONS_CLUSTER_SIZE = 20;
-
 	@Inject
 	private DomNodeLayoutFeeder feeder;
 
@@ -204,7 +202,7 @@ public class PPSemanticLayout extends DeclarativeSemanticFlowLayout {
 			ILayoutContext context) {
 		LayoutUtils.unifyWidthAndAlign(
 			node, grammarAccess.getAttributeOperationAccess().getKeyAttributeNameParserRuleCall_1_0(), Alignment.left,
-			ATTRIBUTE_OPERATIONS_CLUSTER_SIZE);
+			adviceProvider.get().clusterSize());
 		return false;
 	}
 


### PR DESCRIPTION
This commit removes the constant ATTRIBUTE_OPERATIONS_CLUSTER_SIZE
with a value of 20. The value is instead picked from the
IBreakAndAlignAdvice.clusterSize() which corresponds to the
preference setting of:

PP -> Formatter -> Break and Align -> Max Alignment Padding

This preference defines the max when aligning definiton arguments
and assignments. I see no reason why it shouldn't also apply to
attributes.
