### PR TITLE
The future parser will allow literal regular expressions almost

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
@@ -149,6 +149,55 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 	}
 
 	@Test
+	public void test_Regexp_Array() throws Exception {
+		String code = "$x = [/foo/, /bar/]";
+		XtextResource r = getResourceFromString(code);
+		resourceErrorDiagnostics(r).assertOK();
+	}
+
+	@Test
+	public void test_Regexp_Assign() throws Exception {
+		String code = "$x = /foo/";
+		XtextResource r = getResourceFromString(code);
+		resourceErrorDiagnostics(r).assertOK();
+	}
+
+	@Test
+	public void test_Regexp_CallParam() throws Exception {
+		String code = "my_func(/foo/, 'string')";
+		XtextResource r = getResourceFromStringAndExpect(code, 1);
+		resourceErrorDiagnostics(r).assertDiagnostic(IPPDiagnostics.ISSUE__UNKNOWN_FUNCTION_REFERENCE);
+	}
+
+	@Test
+	public void test_Regexp_Equals() throws Exception {
+		String code = "$x = /foo/\n$eq = $x == /foo/";
+		XtextResource r = getResourceFromString(code);
+		resourceErrorDiagnostics(r).assertOK();
+	}
+
+	@Test
+	public void test_Regexp_Hash() throws Exception {
+		String code = "$x = { pattern => /foo/ }";
+		XtextResource r = getResourceFromString(code);
+		resourceErrorDiagnostics(r).assertOK();
+	}
+
+	@Test
+	public void test_Regexp_NotEquals() throws Exception {
+		String code = "$x = /foo/\n$neq = $x != /foo/";
+		XtextResource r = getResourceFromString(code);
+		resourceErrorDiagnostics(r).assertOK();
+	}
+
+	@Test
+	public void test_Regexp_Selector() throws Exception {
+		String code = "$x = $y ? /foo/ => 'Match to foo'";
+		XtextResource r = getResourceFromString(code);
+		resourceErrorDiagnostics(r).assertOK();
+	}
+
+	@Test
 	public void test_Serialize_AppendExpression() {
 		PuppetManifest pp = pf.createPuppetManifest();
 		AppendExpression ae = pf.createAppendExpression();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/lexer/PPLexer.g
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/lexer/PPLexer.g
@@ -41,8 +41,7 @@ import java.util.HashMap;
   private boolean isReAcceptable() {
   	if(singleQuotedString || doubleQuotedString)
   		return false;
-  	// accept after ',' 'node', '{','}, '=~', '!~'
-  	switch(lastSignificantToken) {
+   	switch(lastSignificantToken) {
   		// NOTE: Must manually make sure these refer to the correct KEYWORD numbers
   		case KW_COMMA       : // ','
   		case KW_NODE        : // 'node'
@@ -51,6 +50,13 @@ import java.util.HashMap;
   		case KW_MATCHES     : // '=~'
   		case KW_NOT_MATCHES : // '!~'
   		case KW_INHERITS    : // 'inherits'
+  		case KW_FARROW      : // '=>'
+  		case KW_LBRACK      : // '['
+  		case KW_LPAR        : // '('
+  		case KW_QMARK       : // '?'
+  		case KW_EQ          : // '='
+  		case KW_EQUALS      : // '=='
+  		case KW_NOT_EQ      : // '!='
   		case 0 : // nothing seen before, used when serializing
   			return true;
   		default:


### PR DESCRIPTION
everywhere. The lexer was constrained to only recognize such
expressions when preceeded by one of the tokens:

',', 'node', '{', '}', '=~', '!~', or 'inherits'

This commit will add the following tokens to that list

'(', '[', '=>', '?', '=',  '==', and '!='.

and relevant unit tests.
