### PR TITLE
(GEP-109) Allow any value as hash key

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
@@ -521,10 +521,8 @@ LiteralHash returns pp::LiteralHash
 		'}' 
 	;
 
-// Use LiteralNameOrString to get different literals (to preserve quotes) as opposed to just the token value.
-// TODO: Check constraints on LiteralNameOrString is ${name::name} allowed ?
 HashEntry returns pp::HashEntry
-	: key = LiteralNameOrString '=>'  value = AssignmentExpression
+	: key = AssignmentExpression '=>'  value = AssignmentExpression
 	;
 
 // TODO: Check constraints on LiteralNameOrString is ${name::name} allowed ?

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/formatting/LiteralHashLayout.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/formatting/LiteralHashLayout.java
@@ -107,7 +107,7 @@ public class LiteralHashLayout extends AbstractListLayout {
 					if(DomModelUtils.isWhitespace(nextLeaf))
 						nextLeaf.getStyles().add(StyleSet.withStyles(styles.oneLineBreak()));
 				}
-				else if(ge == hashAccess.getKeyLiteralNameOrStringParserRuleCall_0_0()) {
+				else if(ge == hashAccess.getKeyAssignmentExpressionParserRuleCall_0_0()) {
 					DelegatingLayoutContext keyContext = new DelegatingLayoutContext(context);
 					TextFlow keyFlow = new TextFlow(keyContext);
 					ArrayList<IDomNode> children = Lists.newArrayList(n.getChildren());

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
@@ -96,6 +96,11 @@ public interface IValidationAdvisor extends IPotentialProblemsAdvisor {
 	}
 
 	/**
+	 * The 3.5 --parser future allows any value as hash key
+	 */
+	public boolean allowAnyValueAsHashKey();
+
+	/**
 	 * The 3.2 --parser future allows blocks to end with an expression
 	 */
 	public boolean allowExpressionLastInBlocks();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
@@ -68,6 +68,7 @@ import com.puppetlabs.geppetto.pp.EqualityExpression;
 import com.puppetlabs.geppetto.pp.Expression;
 import com.puppetlabs.geppetto.pp.ExpressionTE;
 import com.puppetlabs.geppetto.pp.FunctionCall;
+import com.puppetlabs.geppetto.pp.HashEntry;
 import com.puppetlabs.geppetto.pp.HostClassDefinition;
 import com.puppetlabs.geppetto.pp.IQuotedString;
 import com.puppetlabs.geppetto.pp.IfExpression;
@@ -1036,6 +1037,23 @@ public class PPJavaValidator extends AbstractPPJavaValidator implements IPPDiagn
 				"Must be a name or reference.", o, PPPackage.Literals.PARAMETERIZED_EXPRESSION__LEFT_EXPR,
 				IPPDiagnostics.ISSUE__NOT_NAME_OR_REF);
 		// rest of validation - valid function - is done during linking
+	}
+
+	@Check
+	public void checkHashEntry(HashEntry o) {
+		if(!advisor().allowAnyValueAsHashKey()) {
+			Expression key = o.getKey();
+			if(key instanceof LiteralNameOrReference) {
+				if(!patternHelper.isNAME(((LiteralNameOrReference) key).getValue()))
+					acceptor.acceptError(
+						"Expected to comply with NAME rule", key, PPPackage.Literals.LITERAL_NAME_OR_REFERENCE__VALUE, INSIGNIFICANT_INDEX,
+						IPPDiagnostics.ISSUE__NOT_NAME);
+			}
+			else if(!(key instanceof SingleQuotedString || key instanceof DoubleQuotedString))
+				acceptor.acceptError(
+					"Key must be a name or string constant", o, PPPackage.Literals.HASH_ENTRY__KEY,
+					IPPDiagnostics.ISSUE__UNSUPPORTED_EXPRESSION);
+		}
 	}
 
 	@Check

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -116,6 +116,14 @@ public class ValidationAdvisor {
 		 * @returns false
 		 */
 		@Override
+		public boolean allowAnyValueAsHashKey() {
+			return false;
+		}
+
+		/**
+		 * @returns false
+		 */
+		@Override
 		public boolean allowExpressionLastInBlocks() {
 			return false;
 		}
@@ -394,6 +402,11 @@ public class ValidationAdvisor {
 	public static class ValidationAdvisor_4_0 extends ValidationAdvisor_3_7 implements IValidationAdvisor {
 		protected ValidationAdvisor_4_0(IPotentialProblemsAdvisor problemsAdvisor) {
 			super(problemsAdvisor);
+		}
+
+		@Override
+		public boolean allowAnyValueAsHashKey() {
+			return true;
 		}
 
 		@Override


### PR DESCRIPTION
This commit changes the parser so that the key in a HashLiteral
can be any expression. It also adds a new allowAnyValueAsHashKey
advice to the IValidationAdvisor. This advice is set to false
for all platforms below 4.0.

The new advice is consulted by the validation logic. When false, it
will perform validity checks on the key to ensure that it is either
a literal that conforms to the NAME rule or a quoted string (single
or double).
