### PR TITLE
(GEP-108) Warn when conditional is used as r-value

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
@@ -431,7 +431,7 @@ Case returns pp::Case
 
 //-- UNLESS (is the same as if !(e) {}, but without support for "else"
 UnlessExpression returns pp::UnlessExpression
-	: 'unless' condExpr = AssignmentExpression '{' (thenStatements += ExpressionList)* '}'
+	: 'unless' condExpr = AssignmentExpression '{' (statements += ExpressionList)* '}'
 		(=>'else' elseStatement = ElseExpression)?
     ;
 	 
@@ -443,7 +443,7 @@ IfExpression returns pp::IfExpression
 	: 'if'  
 		condExpr = AssignmentExpression 
 		'{'  
-			(thenStatements += ExpressionList)*
+			(statements += ExpressionList)*
 		'}' 
 			((=>'elsif' elseStatement=ElseIfExpression)|(=>'else' elseStatement=ElseExpression))?
 	;
@@ -459,7 +459,7 @@ ElseIfExpression returns pp::Expression
 	: 	{pp::ElseIfExpression}
 		condExpr = AssignmentExpression 
 		'{' 
-			(thenStatements += ExpressionList)*
+			(statements += ExpressionList)*
 		'}' 
 			((=>'elsif' elseStatement=ElseIfExpression)|(=>'else' elseStatement=ElseExpression))?
 	;

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/formatting/PPSemanticLayout.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/formatting/PPSemanticLayout.java
@@ -231,7 +231,7 @@ public class PPSemanticLayout extends DeclarativeSemanticFlowLayout {
 	}
 
 	protected boolean _format(ElseIfExpression o, StyleSet styleSet, IDomNode node, ITextFlow flow, ILayoutContext context) {
-		internalFormatStatementList(node, grammarAccess.getElseIfExpressionAccess().getThenStatementsExpressionListParserRuleCall_3_0());
+		internalFormatStatementList(node, grammarAccess.getElseIfExpressionAccess().getStatementsExpressionListParserRuleCall_3_0());
 		return false;
 	}
 
@@ -242,7 +242,7 @@ public class PPSemanticLayout extends DeclarativeSemanticFlowLayout {
 	}
 
 	protected boolean _format(IfExpression o, StyleSet styleSet, IDomNode node, ITextFlow flow, ILayoutContext context) {
-		internalFormatStatementList(node, grammarAccess.getIfExpressionAccess().getThenStatementsExpressionListParserRuleCall_3_0());
+		internalFormatStatementList(node, grammarAccess.getIfExpressionAccess().getStatementsExpressionListParserRuleCall_3_0());
 		return false;
 	}
 
@@ -334,7 +334,7 @@ public class PPSemanticLayout extends DeclarativeSemanticFlowLayout {
 	}
 
 	protected boolean _format(UnlessExpression o, StyleSet styleSet, IDomNode node, ITextFlow flow, ILayoutContext context) {
-		internalFormatStatementList(node, grammarAccess.getUnlessExpressionAccess().getThenStatementsExpressionListParserRuleCall_3_0());
+		internalFormatStatementList(node, grammarAccess.getUnlessExpressionAccess().getStatementsExpressionListParserRuleCall_3_0());
 		return false;
 	}
 

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
@@ -1277,11 +1277,11 @@ public class PPResourceLinker implements IPPDiagnostics {
 					break;
 
 				case PPPackage.IF_EXPRESSION:
-					internalLinkUnparenthesisedCall(((IfExpression) o).getThenStatements(), ctx);
+					internalLinkUnparenthesisedCall(((IfExpression) o).getStatements(), ctx);
 					break;
 
 				case PPPackage.UNLESS_EXPRESSION:
-					internalLinkUnparenthesisedCall(((UnlessExpression) o).getThenStatements(), ctx);
+					internalLinkUnparenthesisedCall(((UnlessExpression) o).getStatements(), ctx);
 					break;
 
 				case PPPackage.ELSE_EXPRESSION:
@@ -1289,7 +1289,7 @@ public class PPResourceLinker implements IPPDiagnostics {
 					break;
 
 				case PPPackage.ELSE_IF_EXPRESSION:
-					internalLinkUnparenthesisedCall(((ElseIfExpression) o).getThenStatements(), ctx);
+					internalLinkUnparenthesisedCall(((ElseIfExpression) o).getStatements(), ctx);
 					break;
 
 				case PPPackage.NODE_DEFINITION:

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/ppformatting/PPExpressionFormatter.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/ppformatting/PPExpressionFormatter.java
@@ -272,7 +272,7 @@ public class PPExpressionFormatter {
 		stream.appendText("{");
 		stream.changeIndentation(1);
 		stream.appendBreaks(1);
-		formatStatementList(o.getThenStatements(), stream);
+		formatStatementList(o.getStatements(), stream);
 		stream.changeIndentation(-1);
 		stream.appendText("}");
 		if(o.getElseStatement() != null) {
@@ -350,7 +350,7 @@ public class PPExpressionFormatter {
 		stream.appendText("{");
 		stream.changeIndentation(1);
 		stream.appendBreaks(1);
-		formatStatementList(o.getThenStatements(), stream);
+		formatStatementList(o.getStatements(), stream);
 		stream.changeIndentation(-1);
 		stream.appendText("}");
 		if(o.getElseStatement() != null) {
@@ -566,7 +566,7 @@ public class PPExpressionFormatter {
 		stream.appendText("{");
 		stream.changeIndentation(1);
 		stream.appendBreaks(1);
-		formatStatementList(o.getThenStatements(), stream);
+		formatStatementList(o.getStatements(), stream);
 		stream.changeIndentation(-1);
 		stream.appendText("}");
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
@@ -148,6 +148,11 @@ public interface IValidationAdvisor extends IPotentialProblemsAdvisor {
 	public boolean allowMoreThan2AtInSequence();
 
 	/**
+	 * The 3.5 with --parser future should allow the expressions if, unless, and case as r-values.
+	 */
+	public boolean allowRHSConditionals();
+
+	/**
 	 * 3.2 --parser future adds an expression separator (';')
 	 */
 	public boolean allowSeparatorExpression();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -188,6 +188,14 @@ public class ValidationAdvisor {
 		 * @returns false
 		 */
 		@Override
+		public boolean allowRHSConditionals() {
+			return false;
+		}
+
+		/**
+		 * @returns false
+		 */
+		@Override
 		public boolean allowSeparatorExpression() {
 			return false;
 		}
@@ -421,6 +429,11 @@ public class ValidationAdvisor {
 
 		@Override
 		public boolean allowLambdas() {
+			return true;
+		}
+
+		@Override
+		public boolean allowRHSConditionals() {
 			return true;
 		}
 

--- a/com.puppetlabs.geppetto.pp/model/PP.ecore
+++ b/com.puppetlabs.geppetto.pp/model/PP.ecore
@@ -26,12 +26,10 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="parent" eType="#//LiteralExpression"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="Definition" eSuperTypes="#//Expression">
+  <eClassifiers xsi:type="ecore:EClass" name="Definition" eSuperTypes="#//ExpressionBlock">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="className" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="arguments" eType="#//DefinitionArgumentList"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="statements" upperBound="-1"
-        eType="#//Expression" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="DefinitionArgumentList">
     <eStructuralFeatures xsi:type="ecore:EReference" name="arguments" upperBound="-1"
@@ -51,17 +49,13 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="cases" upperBound="-1"
         eType="#//Case" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="Case">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="statements" upperBound="-1"
-        eType="#//Expression" containment="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Case" eSuperTypes="#//ExpressionBlock">
     <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1"
         eType="#//Expression" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="IfExpression" eSuperTypes="#//Expression">
+  <eClassifiers xsi:type="ecore:EClass" name="IfExpression" eSuperTypes="#//ExpressionBlock">
     <eStructuralFeatures xsi:type="ecore:EReference" name="condExpr" eType="#//Expression"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="thenStatements" upperBound="-1"
-        eType="#//Expression" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="elseStatement" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
@@ -148,13 +142,11 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1"
         eType="#//Expression" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="NodeDefinition" eSuperTypes="#//Expression">
+  <eClassifiers xsi:type="ecore:EClass" name="NodeDefinition" eSuperTypes="#//ExpressionBlock">
     <eStructuralFeatures xsi:type="ecore:EReference" name="hostNames" upperBound="-1"
         eType="#//Expression" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="parentName" eType="#//Expression"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="statements" upperBound="-1"
-        eType="#//Expression" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="UnaryExpression" abstract="true" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="expr" eType="#//Expression"
@@ -208,11 +200,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="varName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="LiteralClass" eSuperTypes="#//LiteralExpression"/>
-  <eClassifiers xsi:type="ecore:EClass" name="UnlessExpression" eSuperTypes="#//Expression">
+  <eClassifiers xsi:type="ecore:EClass" name="UnlessExpression" eSuperTypes="#//ExpressionBlock">
     <eStructuralFeatures xsi:type="ecore:EReference" name="condExpr" eType="#//Expression"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="thenStatements" upperBound="-1"
-        eType="#//Expression" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="elseStatement" eType="#//Expression"
         containment="true"/>
   </eClassifiers>


### PR DESCRIPTION
A conditional expression (if, unless, case) cannot be an r-value
expression in Puppet versions < 4.0. This commit ensures that they
will be flagged with an error unless the target platform is >= 4.0.

The commit changes the inheritance hierarchy of the pp Expressions
so that if, unless, case, definition, and node are ExpressionBody
subclasses (they all have a sequence of statements). This made it
easy to check if a conditional is directly contained in a body (and
hence allowed) or if it used as an r-value. The one exception
I found to this is when a case is used in a relationship.
