### PR TITLE
(GEP-551) Warn about deprecated variable names

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
@@ -859,8 +859,10 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 		tester.validate(v).assertOK();
 
 		v.setVarName("$3_4");
-		tester.validate(v).assertOK();
+		tester.validate(v).assertWarning(IPPDiagnostics.ISSUE__DEPRECATED_VARIABLE_NAME);
 
+		v.setVarName("$Abc123");
+		tester.validate(v).assertWarning(IPPDiagnostics.ISSUE__DEPRECATED_VARIABLE_NAME);
 	}
 
 }

--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
@@ -110,4 +110,23 @@ public class TestFutureExpressions extends AbstractPuppetTests {
 		v.setVarName("$x");
 		tester.validate(pp).assertOK();
 	}
+
+	@Test
+	public void test_Validate_VariableExpression_NotOk() {
+		PuppetManifest pp = pf.createPuppetManifest();
+		VariableExpression v = pf.createVariableExpression();
+		pp.getStatements().add(v);
+
+		v.setVarName("Abc");
+		tester.validate(v).assertError(IPPDiagnostics.ISSUE__NOT_VARNAME);
+
+		v.setVarName("3b");
+		tester.validate(v).assertError(IPPDiagnostics.ISSUE__NOT_VARNAME);
+
+		v.setVarName("01");
+		tester.validate(v).assertError(IPPDiagnostics.ISSUE__NOT_VARNAME);
+
+		v.setVarName("foo::bar::Fee");
+		tester.validate(v).assertError(IPPDiagnostics.ISSUE__NOT_VARNAME);
+	}
 }

--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestVariables.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestVariables.java
@@ -74,10 +74,10 @@ public class TestVariables extends AbstractPuppetTests implements AbstractPuppet
 		Resource r = loadAndLinkSingleResource(code);
 		tester.validate(r.getContents().get(0)).assertError(IPPDiagnostics.ISSUE__ASSIGNMENT_DECIMAL_VAR);
 
-		// allowed, not decimal
+		// allowed, not decimal. Will yield warning though
 		code = "$01 = 10"; //
 		r = loadAndLinkSingleResource(code);
-		tester.validate(r.getContents().get(0)).assertOK();
+		tester.validate(r.getContents().get(0)).assertWarning(IPPDiagnostics.ISSUE__DEPRECATED_VARIABLE_NAME);
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPotentialProblemsPreferencePage.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPotentialProblemsPreferencePage.java
@@ -33,6 +33,9 @@ public class PPPotentialProblemsPreferencePage extends AbstractPreferencePage {
 			PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED, "Assignment to $trusted", getFieldEditorParent()));
 		addField(new ValidationPreferenceFieldEditor(
 			PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, "Validity not asserted until runtime", getFieldEditorParent()));
+		addField(new ValidationPreferenceFieldEditor(
+			PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, "Deprecated variable name",
+			getFieldEditorParent()));
 	}
 
 }

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
@@ -82,4 +82,6 @@ public class PPPreferenceConstants {
 
 	public static final String PROBLEM_IMPORT_IS_DEPRECATED = "importIsDeprecated";
 
+	public static final String PROBLEM_DEPRECATED_VARIABLE_NAME = "deprecatedVariableName";
+
 }

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
@@ -91,7 +91,8 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED, //
 		PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST, //
 		PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, //
-		PPPreferenceConstants.PROBLEM_IMPORT_IS_DEPRECATED //
+		PPPreferenceConstants.PROBLEM_IMPORT_IS_DEPRECATED, //
+		PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME //
 	);
 
 	private IPreferenceStoreAccess preferenceStoreAccess;
@@ -128,6 +129,10 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 
 	public ValidationPreference getBooleansInStringForm() {
 		return getPreference(PPPreferenceConstants.PROBLEM_BOOLEAN_STRING);
+	}
+
+	public ValidationPreference getDeprecatedVariableName() {
+		return getPreference(PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME);
 	}
 
 	public ValidationPreference getCaseDefaultShouldAppearLast() {
@@ -298,6 +303,7 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		store.setDefault(PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST, ValidationPreference.IGNORE.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, ValidationPreference.IGNORE.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_IMPORT_IS_DEPRECATED, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, ValidationPreference.WARNING.toString());
 
 		// save actions
 		store.setDefault(PPPreferenceConstants.SAVE_ACTION_ENSURE_ENDS_WITH_NL, false);

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
@@ -45,6 +45,11 @@ public class PreferenceBasedPotentialProblemsAdvisor implements IPotentialProble
 	}
 
 	@Override
+	public ValidationPreference deprecatedVariableName() {
+		return preferences.getDeprecatedVariableName();
+	}
+
+	@Override
 	public ValidationPreference caseDefaultShouldAppearLast() {
 		return preferences.getCaseDefaultShouldAppearLast();
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
@@ -191,11 +191,10 @@ public class PPResourceLinker implements IPPDiagnostics {
 			varName = ((LiteralNameOrReference) expr).getValue();
 		if(varName == null)
 			return; // it is some other type of expression - it is validated as expression
-		StringBuilder varName2 = new StringBuilder();
-		if(!varName.startsWith("$"))
-			varName2.append("$");
-		varName2.append(varName);
-		if(patternHelper.isVARIABLE(varName2.toString()))
+		String varNameWithDollar = varName.startsWith("$")
+			? varName
+			: ('$' + varName);
+		if(patternHelper.isVARIABLE(varNameWithDollar) || patternHelper.isDECIMALVAR(varNameWithDollar))
 			internalLinkVariable(expr, PPPackage.Literals.LITERAL_NAME_OR_REFERENCE__VALUE, varName, ctx);
 		else
 			ctx.acceptError("Not a valid variable name", expr, PPPackage.Literals.LITERAL_NAME_OR_REFERENCE__VALUE, ISSUE__NOT_VARNAME);

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
@@ -32,6 +32,11 @@ public class DefaultPotentialProblemsAdvisor implements IPotentialProblemsAdviso
 	}
 
 	@Override
+	public ValidationPreference deprecatedVariableName() {
+		return ValidationPreference.WARNING;
+	}
+
+	@Override
 	public ValidationPreference caseDefaultShouldAppearLast() {
 		return ValidationPreference.IGNORE;
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
@@ -238,4 +238,6 @@ public interface IPPDiagnostics {
 	public static final String ISSUE__UNKNOWN_TYPE_PROP = ISSUE__UNKNOWN_TYPE + ISSUE_PROPOSAL_SUFFIX;
 
 	public static final String ISSUE__TYPE_CONSTRAINT_NOT_FULFILLED = "TypeConstraintNotFulfilled";
+
+	public static final String ISSUE__DEPRECATED_VARIABLE_NAME = "DeprecatedVariableName";
 }

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPotentialProblemsAdvisor.java
@@ -18,12 +18,12 @@ public interface IPotentialProblemsAdvisor extends IStylisticProblemsAdvisor {
 	/**
 	 * How should assignment to variable $string be treated. Puppet bug http://projects.puppetlabs.com/issues/14093.
 	 */
-	public ValidationPreference assignmentToVarNamedString();
+	ValidationPreference assignmentToVarNamedString();
 
 	/**
 	 * How should assignment to variable $trusted be treated.
 	 */
-	public ValidationPreference assignmentToVarNamedTrusted();
+	ValidationPreference assignmentToVarNamedTrusted();
 
 	/**
 	 * Puppet interprets the strings "false" and "true" as boolean true when they are used in a boolean context.
@@ -31,51 +31,56 @@ public interface IPotentialProblemsAdvisor extends IStylisticProblemsAdvisor {
 	 *
 	 * @return
 	 */
-	public ValidationPreference booleansInStringForm();
+	ValidationPreference booleansInStringForm();
+
+	/**
+	 * How should use of deprecated capitalized variable names be reported.
+	 */
+	ValidationPreference deprecatedVariableName();
 
 	/**
 	 * How to validate a dq string - style guide says single quoted should be used if possible.
 	 *
 	 * @return
 	 */
-	public ValidationPreference dqStringNotRequired();
+	ValidationPreference dqStringNotRequired();
 
 	/**
 	 * How to validate a dq string when it only contains a single interpolated variable.
 	 *
 	 * @return
 	 */
-	public ValidationPreference dqStringNotRequiredVariable();
+	ValidationPreference dqStringNotRequiredVariable();
 
 	/**
 	 * How should use of deprecated 'import' keyword be reported.
 	 */
-	public ValidationPreference importIsDeprecated();
+	ValidationPreference importIsDeprecated();
 
 	/**
 	 * How to validate hyphens in non brace enclosed interpolations. In < 2.7 interpolation stops at a hyphen, but
 	 * not in 2.7. Thus when using 2.6 code in 2.7 or vice versa, the result is different.
 	 */
-	public ValidationPreference interpolatedNonBraceEnclosedHyphens();
+	ValidationPreference interpolatedNonBraceEnclosedHyphens();
 
 	/**
 	 * How to validate a missing 'default' in switch type expressions i.e. 'case' and 'selector'
 	 */
-	public ValidationPreference missingDefaultInSelector();
+	ValidationPreference missingDefaultInSelector();
 
 	/**
 	 * How to validate unbraced interpolation.
 	 */
-	public ValidationPreference unbracedInterpolation();
+	ValidationPreference unbracedInterpolation();
 
 	/**
 	 * How to validate a literal resource title. Style guide says they should be single quoted.
 	 */
-	public ValidationPreference unquotedResourceTitles();
+	ValidationPreference unquotedResourceTitles();
 
 	/**
 	 * How should expression validity that cannot be asserted until runtime be reported.
 	 * See Issue GEP-110
 	 */
-	public ValidationPreference validityAssertedAtRuntime();
+	ValidationPreference validityAssertedAtRuntime();
 }

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPPatternHelper.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPPatternHelper.java
@@ -38,6 +38,8 @@ public class PPPatternHelper {
 
 	protected final Pattern regexpPattern;
 
+	protected final Pattern deprecatedVariablePattern;
+
 	protected final Pattern variablePattern;
 
 	protected final Pattern sqStringPattern;
@@ -50,7 +52,7 @@ public class PPPatternHelper {
 
 	protected final Pattern recognizedDQEscapes;
 
-	protected final Pattern decimalVarPattern;
+	protected final Pattern decimalVariablePattern;
 
 	/**
 	 * Intended as Ruby %r{[\w-]} equivalence
@@ -78,7 +80,15 @@ public class PPPatternHelper {
 		// start with a * - '/*...'
 		// contain newline character
 		regexpPattern = Pattern.compile("/([^/\\n\\*\\\\]|(\\\\[^\\n]))([^/\\n\\\\]|(\\\\[^\\n]))*/[a-z]*");
-		variablePattern = Pattern.compile("\\$(::)?(" + VAR_CHAR + "+::)*" + VAR_CHAR + "+");
+
+		// For regexp match results
+		decimalVariablePattern = Pattern.compile("\\$?([0]|([1-9][0-9]*))");
+
+		// For versions < 4.0
+		deprecatedVariablePattern = Pattern.compile("\\$(::)?(" + VAR_CHAR + "+::)*" + VAR_CHAR + "+");
+
+		// For versoins >= 4.0
+		variablePattern = Pattern.compile("\\$(:?(::)?[a-z]\\w*)*(:?(::)?[a-z_]\\w*)");
 
 		// sq string may not contain unescaped single quote
 		sqStringPattern = Pattern.compile("([^'\\\\]|\\\\.)*");
@@ -90,8 +100,6 @@ public class PPPatternHelper {
 		unrecognizedDQEscapes = Pattern.compile("\\\\[^stn '\"\\\\\\r\\n\\$]");
 
 		recognizedDQEscapes = Pattern.compile("\\\\[\\\\nrst'\" \\$]");
-
-		decimalVarPattern = Pattern.compile("\\$?([0]|([1-9][0-9]*))");
 	}
 
 	/**
@@ -147,7 +155,13 @@ public class PPPatternHelper {
 	public boolean isDECIMALVAR(String s) {
 		if(s == null || s.length() == 0)
 			return false;
-		return decimalVarPattern.matcher(s).matches();
+		return decimalVariablePattern.matcher(s).matches();
+	}
+
+	public boolean isDEPRECATED_VARIABLE(String s) {
+		if(s == null || s.length() == 0)
+			return false;
+		return deprecatedVariablePattern.matcher(s).matches();
 	}
 
 	public boolean isNAME(String s) {

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -36,6 +36,11 @@ public class ValidationAdvisor {
 		}
 
 		@Override
+		public ValidationPreference deprecatedVariableName() {
+			return problemsAdvisor.deprecatedVariableName();
+		}
+
+		@Override
 		public ValidationPreference caseDefaultShouldAppearLast() {
 			return problemsAdvisor.caseDefaultShouldAppearLast();
 		}
@@ -440,9 +445,13 @@ public class ValidationAdvisor {
 		}
 
 		@Override
-		public ValidationPreference importIsDeprecated() {
+		public ValidationPreference deprecatedVariableName() {
 			return ValidationPreference.ERROR;
 		}
 
+		@Override
+		public ValidationPreference importIsDeprecated() {
+			return ValidationPreference.ERROR;
+		}
 	}
 }


### PR DESCRIPTION
A Name starting with an upper case letter or a digit (but is't
a decimal number without leading zeroes) will become deprecated
in future versions of puppet. This commit ensures that Geppetto
can warn about such names (optional setting but the default is
to warn) and that such names will result in error when the future
platform is used.
