### PR TITLE
(GEP-111) Support chained assignments

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
@@ -597,6 +597,31 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 	}
 
 	/**
+	 * Tests that chained assignemt is not ok
+	 * - $x = $y = expr
+	 */
+	@Test
+	public void test_Validate_AssignmentExpression_NotOk_Chained() {
+		PuppetManifest pp = pf.createPuppetManifest();
+		AssignmentExpression ax = pf.createAssignmentExpression();
+		VariableExpression v = pf.createVariableExpression();
+		v.setVarName("$x");
+		ax.setLeftExpr(v);
+
+		AssignmentExpression ay = pf.createAssignmentExpression();
+		VariableExpression y = pf.createVariableExpression();
+		y.setVarName("$y");
+		ay.setLeftExpr(y);
+
+		LiteralBoolean b = pf.createLiteralBoolean();
+		ay.setRightExpr(b);
+		ax.setRightExpr(ay);
+		pp.getStatements().add(ax);
+
+		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__ASSIGNMENT_CHAINED);
+	}
+
+	/**
 	 * Tests assignment not ok states:
 	 * - $0 = expr
 	 */

--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.junit.Test;
 
 import com.puppetlabs.geppetto.pp.AppendExpression;
+import com.puppetlabs.geppetto.pp.AssignmentExpression;
 import com.puppetlabs.geppetto.pp.LiteralBoolean;
 import com.puppetlabs.geppetto.pp.LiteralNameOrReference;
 import com.puppetlabs.geppetto.pp.MatchingExpression;
@@ -70,6 +71,31 @@ public class TestFutureExpressions extends AbstractPuppetTests {
 		pp.getStatements().add(ae);
 
 		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED);
+	}
+
+	/**
+	 * Tests that chained assignemt is ok
+	 * - $x = $y = expr
+	 */
+	@Test
+	public void test_Validate_AssignmentExpression_NotOk_Chained() {
+		PuppetManifest pp = pf.createPuppetManifest();
+		AssignmentExpression ax = pf.createAssignmentExpression();
+		VariableExpression v = pf.createVariableExpression();
+		v.setVarName("$x");
+		ax.setLeftExpr(v);
+
+		AssignmentExpression ay = pf.createAssignmentExpression();
+		VariableExpression y = pf.createVariableExpression();
+		y.setVarName("$y");
+		ay.setLeftExpr(y);
+
+		LiteralBoolean b = pf.createLiteralBoolean();
+		ay.setRightExpr(b);
+		ax.setRightExpr(ay);
+		pp.getStatements().add(ax);
+
+		tester.validate(pp).assertOK();
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
@@ -141,7 +141,7 @@ endComma : ',' ;
 AssignmentExpression returns pp::Expression
 	: AppendExpression ({pp::AssignmentExpression.leftExpr = current}
 		'='  
-		rightExpr = AppendExpression
+		rightExpr = AssignmentExpression
 	  )? 
   	;
 

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
@@ -28,6 +28,8 @@ public interface IPPDiagnostics {
 
 	public static final String ISSUE__AMBIGUOUS_REFERENCE = ISSUE_PREFIX + "AmbigousReference";
 
+	public static final String ISSUE__ASSIGNMENT_CHAINED = ISSUE_PREFIX + "AssignmentChained";
+
 	public static final String ISSUE__ASSIGNMENT_DECIMAL_VAR = ISSUE_PREFIX + "AssignmentDecimalVar";
 
 	public static final String ISSUE__ASSIGNMENT_OTHER_NAMESPACE = ISSUE_PREFIX + "AssignmentOtherNamespace";

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
@@ -101,6 +101,11 @@ public interface IValidationAdvisor extends IPotentialProblemsAdvisor {
 	public boolean allowAnyValueAsHashKey();
 
 	/**
+	 * The 3.5 --parser future allows chained assignments
+	 */
+	public boolean allowChainedAssignments();
+
+	/**
 	 * The 3.2 --parser future allows blocks to end with an expression
 	 */
 	public boolean allowExpressionLastInBlocks();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
@@ -429,8 +429,13 @@ public class PPJavaValidator extends AbstractPPJavaValidator implements IPPDiagn
 		if(leftExpr instanceof VariableExpression)
 			checkAssignability(o, (VariableExpression) leftExpr);
 
-		// TODO: rhs is not validated, it allows expression, which includes rvalue, but some top level expressions
-		// are probably not allowed (case?)
+		Expression rightExpr = o.getRightExpr();
+		if(rightExpr instanceof AssignmentExpression) {
+			if(!advisor().allowChainedAssignments())
+				acceptor.acceptError(
+					"Chained assignments not allowed in versions < 4.0", o, PPPackage.Literals.BINARY_EXPRESSION__RIGHT_EXPR,
+					INSIGNIFICANT_INDEX, IPPDiagnostics.ISSUE__ASSIGNMENT_CHAINED);
+		}
 	}
 
 	/**

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -134,6 +134,14 @@ public class ValidationAdvisor {
 		 * @returns false
 		 */
 		@Override
+		public boolean allowChainedAssignments() {
+			return false;
+		}
+
+		/**
+		 * @returns false
+		 */
+		@Override
 		public boolean allowExpressionLastInBlocks() {
 			return false;
 		}
@@ -424,6 +432,11 @@ public class ValidationAdvisor {
 
 		@Override
 		public boolean allowAnyValueAsHashKey() {
+			return true;
+		}
+
+		@Override
+		public boolean allowChainedAssignments() {
 			return true;
 		}
 


### PR DESCRIPTION
(GEP-111) Support chained assignments

Allow AssignmentExpression as RHS in AssignmentExpression and
let validator generate errors when this construct is detected
if the platform in use is version < 4.0
