### PR TITLE
(GEP-164) Handle dropped support for operator += in 4.0

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
@@ -513,10 +513,14 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 		ae.setLeftExpr(at);
 		ae.setRightExpr(b);
 
-		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__NOT_APPENDABLE);
+		tester.validate(pp).assertAll(
+			AssertableDiagnostics.errorCode(IPPDiagnostics.ISSUE__NOT_APPENDABLE),
+			AssertableDiagnostics.warningCode(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED));
 
 		ae.setLeftExpr(createNameOrReference("a"));
-		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__NOT_APPENDABLE);
+		tester.validate(pp).assertAll(
+			AssertableDiagnostics.errorCode(IPPDiagnostics.ISSUE__NOT_APPENDABLE),
+			AssertableDiagnostics.warningCode(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED));
 
 	}
 
@@ -535,8 +539,9 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 		ae.setRightExpr(b);
 		pp.getStatements().add(ae);
 
-		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__ASSIGNMENT_DECIMAL_VAR);
-
+		tester.validate(pp).assertAll(
+			AssertableDiagnostics.errorCode(IPPDiagnostics.ISSUE__ASSIGNMENT_DECIMAL_VAR),
+			AssertableDiagnostics.warningCode(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED));
 	}
 
 	/**
@@ -554,12 +559,13 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 		ae.setRightExpr(b);
 		pp.getStatements().add(ae);
 
-		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__ASSIGNMENT_OTHER_NAMESPACE);
-
+		tester.validate(pp).assertAll(
+			AssertableDiagnostics.errorCode(IPPDiagnostics.ISSUE__ASSIGNMENT_OTHER_NAMESPACE),
+			AssertableDiagnostics.warningCode(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED));
 	}
 
 	/**
-	 * Tests append ok states:
+	 * Test that append gives a deprecation warning.
 	 * - $x += expr
 	 */
 	@Test
@@ -573,7 +579,7 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 		ae.setRightExpr(b);
 		pp.getStatements().add(ae);
 
-		tester.validate(pp).assertOK();
+		tester.validate(pp).assertWarning(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED);
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
@@ -13,6 +13,8 @@ package com.puppetlabs.geppetto.pp.dsl.tests;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.junit.Test;
 
+import com.puppetlabs.geppetto.pp.AppendExpression;
+import com.puppetlabs.geppetto.pp.LiteralBoolean;
 import com.puppetlabs.geppetto.pp.LiteralNameOrReference;
 import com.puppetlabs.geppetto.pp.MatchingExpression;
 import com.puppetlabs.geppetto.pp.PuppetManifest;
@@ -50,6 +52,24 @@ public class TestFutureExpressions extends AbstractPuppetTests {
 		Resource r = loadAndLinkSingleResource(code);
 		String s = serialize(r.getContents().get(0));
 		assertEquals("serialization should produce same result", code, s);
+	}
+
+	/**
+	 * Test that append is an error.
+	 * - $x += expr
+	 */
+	@Test
+	public void test_Validate_AppendExpression_Ok() {
+		PuppetManifest pp = pf.createPuppetManifest();
+		AppendExpression ae = pf.createAppendExpression();
+		LiteralBoolean b = pf.createLiteralBoolean();
+		VariableExpression v = pf.createVariableExpression();
+		v.setVarName("$x");
+		ae.setLeftExpr(v);
+		ae.setRightExpr(b);
+		pp.getStatements().add(ae);
+
+		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED);
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestLinking.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestLinking.java
@@ -20,6 +20,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.puppetlabs.geppetto.pp.dsl.validation.IPPDiagnostics;
+
 /**
  * Test validation/linking of variables.
  */
@@ -72,7 +74,7 @@ public class TestLinking extends AbstractPuppetTests {
 		// XtextResource r = getResourceFromString(code);
 		List<Resource> resources = loadAndLinkResources(code1, code2);
 		Resource r = resources.get(0);
-		tester.validate(r.getContents().get(0)).assertOK();
+		tester.validate(r.getContents().get(0)).assertWarning(IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED);
 		resourceWarningDiagnostics(r).assertOK();
 		resourceErrorDiagnostics(r).assertOK();
 

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPotentialProblemsPreferencePage.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPotentialProblemsPreferencePage.java
@@ -34,8 +34,12 @@ public class PPPotentialProblemsPreferencePage extends AbstractPreferencePage {
 		addField(new ValidationPreferenceFieldEditor(
 			PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, "Validity not asserted until runtime", getFieldEditorParent()));
 		addField(new ValidationPreferenceFieldEditor(
-			PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, "Deprecated variable name",
+			PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, "Use of deprecated variable name",
 			getFieldEditorParent()));
+		addField(new ValidationPreferenceFieldEditor(
+			PPPreferenceConstants.PROBLEM_IMPORT_IS_DEPRECATED, "Use of deprecated 'import' keyword", getFieldEditorParent()));
+		addField(new ValidationPreferenceFieldEditor(
+			PPPreferenceConstants.PROBLEM_PLUS_EQUALS_IS_DEPRECATED, "Use of deprecated += operator", getFieldEditorParent()));
 	}
 
 }

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
@@ -84,4 +84,6 @@ public class PPPreferenceConstants {
 
 	public static final String PROBLEM_DEPRECATED_VARIABLE_NAME = "deprecatedVariableName";
 
+	public static final String PROBLEM_PLUS_EQUALS_IS_DEPRECATED = "plusEqualsIsDeprecated";
+
 }

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
@@ -92,7 +92,8 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST, //
 		PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, //
 		PPPreferenceConstants.PROBLEM_IMPORT_IS_DEPRECATED, //
-		PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME //
+		PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, //
+		PPPreferenceConstants.PROBLEM_PLUS_EQUALS_IS_DEPRECATED //
 	);
 
 	private IPreferenceStoreAccess preferenceStoreAccess;
@@ -173,6 +174,10 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 
 	public ValidationPreference getMLCommentsValidationPreference() {
 		return getPreference(PPPreferenceConstants.PROBLEM_ML_COMMENTS);
+	}
+
+	public ValidationPreference getPlusEqualsIsDeprecated() {
+		return getPreference(PPPreferenceConstants.PROBLEM_PLUS_EQUALS_IS_DEPRECATED);
 	}
 
 	private ValidationPreference getPreference(String prefId) {
@@ -304,6 +309,7 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		store.setDefault(PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, ValidationPreference.IGNORE.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_IMPORT_IS_DEPRECATED, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_PLUS_EQUALS_IS_DEPRECATED, ValidationPreference.WARNING.toString());
 
 		// save actions
 		store.setDefault(PPPreferenceConstants.SAVE_ACTION_ENSURE_ENDS_WITH_NL, false);

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
@@ -93,6 +93,11 @@ public class PreferenceBasedPotentialProblemsAdvisor implements IPotentialProble
 	}
 
 	@Override
+	public ValidationPreference plusEqualsIsDeprecated() {
+		return preferences.getPlusEqualsIsDeprecated();
+	}
+
+	@Override
 	public ValidationPreference rightToLeftRelationships() {
 		return preferences.getRightToLeftRelationships();
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
@@ -77,6 +77,11 @@ public class DefaultPotentialProblemsAdvisor implements IPotentialProblemsAdviso
 	}
 
 	@Override
+	public ValidationPreference plusEqualsIsDeprecated() {
+		return ValidationPreference.WARNING;
+	}
+
+	@Override
 	public ValidationPreference rightToLeftRelationships() {
 		return ValidationPreference.IGNORE;
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
@@ -240,4 +240,6 @@ public interface IPPDiagnostics {
 	public static final String ISSUE__TYPE_CONSTRAINT_NOT_FULFILLED = "TypeConstraintNotFulfilled";
 
 	public static final String ISSUE__DEPRECATED_VARIABLE_NAME = "DeprecatedVariableName";
+
+	public static final String ISSUE__PLUS_EQUALS_IS_DEPRECATED = ISSUE_PREFIX + "PlusEqualsIsDeprecated";
 }

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPotentialProblemsAdvisor.java
@@ -69,6 +69,11 @@ public interface IPotentialProblemsAdvisor extends IStylisticProblemsAdvisor {
 	ValidationPreference missingDefaultInSelector();
 
 	/**
+	 * How should use of deprecated '-=' and '+=' operators be reported.
+	 */
+	public ValidationPreference plusEqualsIsDeprecated();
+
+	/**
 	 * How to validate unbraced interpolation.
 	 */
 	ValidationPreference unbracedInterpolation();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
@@ -358,6 +358,17 @@ public class PPJavaValidator extends AbstractPPJavaValidator implements IPPDiagn
 
 	@Check
 	public void checkAppendExpression(AppendExpression o) {
+		ValidationPreference peIsDeprecated = advisor().plusEqualsIsDeprecated();
+		if(peIsDeprecated != ValidationPreference.IGNORE) {
+			if(peIsDeprecated == ValidationPreference.ERROR)
+				acceptor.acceptError(
+					"The operator '+=' is no longer supported. See http://links.puppetlabs.com/remove-plus-equals", o,
+					IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED);
+			else
+				acceptor.acceptWarning(
+					"The operator '+=' is deprecated and will become illegal in future versions of Puppet. See http://links.puppetlabs.com/remove-plus-equals",
+					o, IPPDiagnostics.ISSUE__PLUS_EQUALS_IS_DEPRECATED);
+		}
 		Expression leftExpr = o.getLeftExpr();
 		if(!(leftExpr instanceof VariableExpression))
 			acceptor.acceptError(

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -81,6 +81,11 @@ public class ValidationAdvisor {
 		}
 
 		@Override
+		public ValidationPreference plusEqualsIsDeprecated() {
+			return problemsAdvisor.plusEqualsIsDeprecated();
+		}
+
+		@Override
 		public ValidationPreference rightToLeftRelationships() {
 			return problemsAdvisor.rightToLeftRelationships();
 		}
@@ -464,6 +469,11 @@ public class ValidationAdvisor {
 
 		@Override
 		public ValidationPreference importIsDeprecated() {
+			return ValidationPreference.ERROR;
+		}
+
+		@Override
+		public ValidationPreference plusEqualsIsDeprecated() {
 			return ValidationPreference.ERROR;
 		}
 	}


### PR DESCRIPTION
Add a preference that controls reporting when the deprecated
+= operator is used. The default setting for this preference
is 'warning'. The preference is hardcoded to error in when
using version 4.0.
