### PR TITLE
(GEP-179) Handle dropped support for node inheritance

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestExpressions.java
@@ -37,6 +37,7 @@ import com.puppetlabs.geppetto.pp.LiteralBoolean;
 import com.puppetlabs.geppetto.pp.LiteralNameOrReference;
 import com.puppetlabs.geppetto.pp.LiteralRegex;
 import com.puppetlabs.geppetto.pp.MatchingExpression;
+import com.puppetlabs.geppetto.pp.NodeDefinition;
 import com.puppetlabs.geppetto.pp.PuppetManifest;
 import com.puppetlabs.geppetto.pp.RelationshipExpression;
 import com.puppetlabs.geppetto.pp.ResourceExpression;
@@ -765,6 +766,17 @@ public class TestExpressions extends AbstractPuppetTests implements AbstractPupp
 
 		me.setOpName("!~");
 		tester.validate(me).assertOK();
+	}
+
+	@Test
+	public void test_Validate_NodeDefinitionExpression_Ok() {
+		PuppetManifest pp = pf.createPuppetManifest();
+		NodeDefinition nd = pf.createNodeDefinition();
+		nd.getHostNames().add(createNameOrReference("common"));
+		pp.getStatements().add(nd);
+		tester.validate(pp).assertOK();
+		nd.setParentName(pf.createLiteralDefault());
+		tester.validate(pp).assertWarning(IPPDiagnostics.ISSUE__DEPRECATED_NODE_INHERITANCE);
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureExpressions.java
@@ -18,6 +18,7 @@ import com.puppetlabs.geppetto.pp.AssignmentExpression;
 import com.puppetlabs.geppetto.pp.LiteralBoolean;
 import com.puppetlabs.geppetto.pp.LiteralNameOrReference;
 import com.puppetlabs.geppetto.pp.MatchingExpression;
+import com.puppetlabs.geppetto.pp.NodeDefinition;
 import com.puppetlabs.geppetto.pp.PuppetManifest;
 import com.puppetlabs.geppetto.pp.SingleQuotedString;
 import com.puppetlabs.geppetto.pp.VariableExpression;
@@ -142,6 +143,16 @@ public class TestFutureExpressions extends AbstractPuppetTests {
 		pp.getStatements().add(me);
 
 		tester.validate(me).assertWarning(IPPDiagnostics.ISSUE__VALIDITY_ASSERTED_AT_RUNTIME);
+	}
+
+	@Test
+	public void test_Validate_NodeDefinitionExpression_NotOk_Inheritance() {
+		PuppetManifest pp = pf.createPuppetManifest();
+		NodeDefinition nd = pf.createNodeDefinition();
+		nd.getHostNames().add(createNameOrReference("common"));
+		nd.setParentName(pf.createLiteralDefault());
+		pp.getStatements().add(nd);
+		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__DEPRECATED_NODE_INHERITANCE);
 	}
 
 	/**

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPotentialProblemsPreferencePage.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPotentialProblemsPreferencePage.java
@@ -38,6 +38,8 @@ public class PPPotentialProblemsPreferencePage extends AbstractPreferencePage {
 		addField(new ValidationPreferenceFieldEditor(
 			PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT, "Use of deprecated 'import' keyword", getFieldEditorParent()));
 		addField(new ValidationPreferenceFieldEditor(
+			PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE, "Use of deprecated node inheritance", getFieldEditorParent()));
+		addField(new ValidationPreferenceFieldEditor(
 			PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, "Use of deprecated variable name", getFieldEditorParent()));
 	}
 

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
@@ -33,6 +33,8 @@ public class PPPreferenceConstants {
 
 	public static final String PROBLEM_DEPRECATED_IMPORT = "importIsDeprecated";
 
+	public static final String PROBLEM_DEPRECATED_NODE_INHERITANCE = "deprecatedNodeInheritance";
+
 	public static final String PROBLEM_DEPRECATED_PLUS_EQUALS = "deprecatedPlusEquals";
 
 	public static final String PROBLEM_DEPRECATED_VARIABLE_NAME = "deprecatedVariableName";

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
@@ -93,7 +93,7 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, //
 		PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT, //
 		PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, //
-		PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS //
+		PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS, PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE //
 	);
 
 	private IPreferenceStoreAccess preferenceStoreAccess;
@@ -142,6 +142,10 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 
 	public ValidationPreference getDeprecatedImport() {
 		return getPreference(PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT);
+	}
+
+	public ValidationPreference getDeprecatedNodeInheritance() {
+		return getPreference(PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE);
 	}
 
 	public ValidationPreference getDeprecatedPlusEquals() {
@@ -310,6 +314,7 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE, ValidationPreference.WARNING.toString());
 
 		// save actions
 		store.setDefault(PPPreferenceConstants.SAVE_ACTION_ENSURE_ENDS_WITH_NL, false);

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
@@ -55,6 +55,11 @@ public class PreferenceBasedPotentialProblemsAdvisor implements IPotentialProble
 	}
 
 	@Override
+	public ValidationPreference deprecatedNodeInheritance() {
+		return preferences.getDeprecatedNodeInheritance();
+	}
+
+	@Override
 	public ValidationPreference deprecatedPlusEquals() {
 		return preferences.getDeprecatedPlusEquals();
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
@@ -42,6 +42,11 @@ public class DefaultPotentialProblemsAdvisor implements IPotentialProblemsAdviso
 	}
 
 	@Override
+	public ValidationPreference deprecatedNodeInheritance() {
+		return ValidationPreference.WARNING;
+	}
+
+	@Override
 	public ValidationPreference deprecatedPlusEquals() {
 		return ValidationPreference.WARNING;
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
@@ -44,6 +44,8 @@ public interface IPPDiagnostics {
 
 	public static final String ISSUE__DEPRECATED_IMPORT = ISSUE_PREFIX + "DeprecatedImport";
 
+	public static final String ISSUE__DEPRECATED_NODE_INHERITANCE = ISSUE_PREFIX + "DeprecatedNodeInheritance";
+
 	public static final String ISSUE__DEPRECATED_PLUS_EQUALS = ISSUE_PREFIX + "DeprecatedPlusEquals";
 
 	public static final String ISSUE__DEPRECATED_REFERENCE = ISSUE_PREFIX + "DeprecatedReference";

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPotentialProblemsAdvisor.java
@@ -39,6 +39,11 @@ public interface IPotentialProblemsAdvisor extends IStylisticProblemsAdvisor {
 	ValidationPreference deprecatedImport();
 
 	/**
+	 * How should use of deprecated node inheritance be reported.
+	 */
+	ValidationPreference deprecatedNodeInheritance();
+
+	/**
 	 * How should use of deprecated '-=' and '+=' operators be reported.
 	 */
 	ValidationPreference deprecatedPlusEquals();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/PPJavaValidator.java
@@ -1270,11 +1270,22 @@ public class PPJavaValidator extends AbstractPPJavaValidator implements IPPDiagn
 
 		Expression parentExpr = o.getParentName();
 		if(parentExpr != null) {
-			String parentName = stringConstantEvaluator.doToString(parentExpr);
-			if(parentName == null)
-				acceptor.acceptError(
-					"Must be a constant name/string expression.", o, PPPackage.Literals.NODE_DEFINITION__PARENT_NAME, INSIGNIFICANT_INDEX,
-					IPPDiagnostics.ISSUE__NOT_CONSTANT);
+			ValidationPreference deprecatedNI = advisor().deprecatedNodeInheritance();
+			if(deprecatedNI != ValidationPreference.IGNORE)
+				warningOrError(
+					acceptor,
+					deprecatedNI,
+					"Node inheritance is not supported in Puppet >= 4.0. See http://links.puppetlabs.com/puppet-node-inheritance-deprecation",
+					o, PPPackage.Literals.NODE_DEFINITION__PARENT_NAME, INSIGNIFICANT_INDEX,
+					IPPDiagnostics.ISSUE__DEPRECATED_NODE_INHERITANCE);
+
+			if(deprecatedNI != ValidationPreference.ERROR) {
+				String parentName = stringConstantEvaluator.doToString(parentExpr);
+				if(parentName == null)
+					acceptor.acceptError(
+						"Must be a constant name/string expression.", o, PPPackage.Literals.NODE_DEFINITION__PARENT_NAME,
+						INSIGNIFICANT_INDEX, IPPDiagnostics.ISSUE__NOT_CONSTANT);
+			}
 		}
 	}
 
@@ -2143,7 +2154,7 @@ public class PPJavaValidator extends AbstractPPJavaValidator implements IPPDiagn
 		if(validationPreference.isWarning())
 			acceptor.acceptWarning(message, o, feature, index, issueCode);
 		else if(validationPreference.isError())
-			acceptor.acceptWarning(message, o, feature, index, issueCode);
+			acceptor.acceptError(message, o, feature, index, issueCode);
 	}
 
 	private void warningOrError(IMessageAcceptor acceptor, ValidationPreference validationPreference, String message, EObject o,

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -46,6 +46,11 @@ public class ValidationAdvisor {
 		}
 
 		@Override
+		public ValidationPreference deprecatedNodeInheritance() {
+			return problemsAdvisor.deprecatedNodeInheritance();
+		}
+
+		@Override
 		public ValidationPreference deprecatedPlusEquals() {
 			return problemsAdvisor.deprecatedPlusEquals();
 		}
@@ -477,6 +482,11 @@ public class ValidationAdvisor {
 
 		@Override
 		public ValidationPreference deprecatedImport() {
+			return ValidationPreference.ERROR;
+		}
+
+		@Override
+		public ValidationPreference deprecatedNodeInheritance() {
 			return ValidationPreference.ERROR;
 		}
 


### PR DESCRIPTION
Node inheritance is no longer supported in Puppet versions >= 4.0.
This commit ensures that Geppetto will warn about this deprecation
in older versions (can be ignored by changing default preference
setting). Versions >= 4.0 will always report errors.
