### PR TITLE
(GEP-171) Support the * => syntax in resource expression

### DIFF
--- a/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureResourceExpr.java
+++ b/com.puppetlabs.geppetto.pp.dsl.tests/src/com/puppetlabs/geppetto/pp/dsl/tests/TestFutureResourceExpr.java
@@ -11,14 +11,85 @@
  */
 package com.puppetlabs.geppetto.pp.dsl.tests;
 
+import static org.eclipse.xtext.junit4.validation.AssertableDiagnostics.errorCode;
+
+import java.util.List;
+
+import org.eclipse.emf.common.util.EList;
 import org.junit.Test;
 
+import com.puppetlabs.geppetto.pp.Expression;
+import com.puppetlabs.geppetto.pp.HashEntry;
+import com.puppetlabs.geppetto.pp.LiteralHash;
+import com.puppetlabs.geppetto.pp.PuppetManifest;
+import com.puppetlabs.geppetto.pp.ResourceExpression;
+import com.puppetlabs.geppetto.pp.dsl.validation.IPPDiagnostics;
 import com.puppetlabs.geppetto.pp.dsl.validation.IValidationAdvisor.ComplianceLevel;
 
 public class TestFutureResourceExpr extends AbstractPuppetTests {
+	protected LiteralHash createHash(String... keyValuePairs) {
+		int len = keyValuePairs.length;
+		assertTrue("Key value pair array must have even number of elements", len % 2 == 0);
+		LiteralHash hash = pf.createLiteralHash();
+		List<HashEntry> elems = hash.getElements();
+		for(int idx = 0; idx < len;) {
+			HashEntry he = pf.createHashEntry();
+			he.setKey(createNameOrReference(keyValuePairs[idx++]));
+			he.setValue(createValue(keyValuePairs[idx++]));
+			elems.add(he);
+		}
+		return hash;
+	}
+
 	@Override
 	protected ComplianceLevel getComplianceLevel() {
 		return ComplianceLevel.PUPPET_4_0;
+	}
+
+	@Test
+	public void test_Validate_RegularResourceNotOk_SplashDuplicate() {
+		// -- Resource with a couple of attribute definitions
+		PuppetManifest pp = pf.createPuppetManifest();
+		EList<Expression> statements = pp.getStatements();
+		ResourceExpression re = createResourceExpression(
+			"file", "a resource", "owner", createValue("0777"), "*", createHash("group", "0666", "other", "0555"), "*",
+			createHash("group", "0666", "other", "0555"));
+		statements.add(re);
+
+		// Will occur twice. Once on each duplicate.
+		tester.validate(pp).assertAll(
+			errorCode(IPPDiagnostics.ISSUE__RESOURCE_DUPLICATE_ATTRIBUTE), errorCode(IPPDiagnostics.ISSUE__RESOURCE_DUPLICATE_ATTRIBUTE));
+	}
+
+	@Test
+	public void test_Validate_RegularResourceNotOk_SplashNotHash() {
+		// -- Resource with a couple of attribute definitions
+		PuppetManifest pp = pf.createPuppetManifest();
+		EList<Expression> statements = pp.getStatements();
+		ResourceExpression re = createResourceExpression("file", "a resource", "owner", createValue("0777"), "*", createValue("0555"));
+		statements.add(re);
+		tester.validate(pp).assertError(IPPDiagnostics.ISSUE__SPLASH_VALUE_MUST_BE_HASH);
+	}
+
+	@Test
+	public void test_Validate_RegularResourceOk_Splash() {
+		// -- Resource with a couple of attribute definitions
+		PuppetManifest pp = pf.createPuppetManifest();
+		EList<Expression> statements = pp.getStatements();
+		ResourceExpression re = createResourceExpression(
+			"file", "a resource", "owner", createValue("0777"), "*", createHash("group", "0666", "other", "0555"));
+		statements.add(re);
+		tester.validate(pp).assertOK();
+	}
+
+	@Test
+	public void test_Validate_RegularResourceOk_SplashVariable() {
+		// -- Resource with a couple of attribute definitions
+		PuppetManifest pp = pf.createPuppetManifest();
+		EList<Expression> statements = pp.getStatements();
+		ResourceExpression re = createResourceExpression("file", "a resource", "owner", createValue("0777"), "*", createVariable("h"));
+		statements.add(re);
+		tester.validate(pp).assertOK();
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/PP.xtext
@@ -640,7 +640,7 @@ keyword : ('and' | 'case' | 'class' | 'default' | 'define' | 'else' | 'elsif' | 
 		| 'import' | 'node' | 'or' | 'undef' | 'true' | 'false' | 'if' | 'unless')
 	;
 
-attributeName : name | keyword;
+attributeName : name | keyword | '*';
 
 name
 	// a puppet grammar glitch allows '::' any number of times (\w*::)*\w+. Validation checks correctness.

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/linking/PPResourceLinker.java
@@ -632,7 +632,12 @@ public class PPResourceLinker implements IPPDiagnostics {
 
 		if(aos != null && desc != null)
 			for(AttributeOperation ao : aos.getAttributes()) {
-				QualifiedName fqn = desc.getQualifiedName().append(ao.getKey());
+				String key = ao.getKey();
+				if("*".equals(key))
+					// Linking not applicable
+					continue;
+
+				QualifiedName fqn = desc.getQualifiedName().append(key);
 				// Accept name if there is at least one type/definition that lists the key
 				// NOTE/TODO: If there are other problems (multiple definitions with same name etc,
 				// the property could be ok in one, but not in another instance.

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
@@ -181,6 +181,8 @@ public interface IPPDiagnostics {
 
 	public static final String ISSUE__RESOURCE_WITHOUT_TITLE = ISSUE_PREFIX + "ResourceWithoutTitle";
 
+	public static final String ISSUE__SPLASH_VALUE_MUST_BE_HASH = ISSUE_PREFIX + "SplashValueMustBeHash";
+
 	public static final String ISSUE__STRING_BOOLEAN = ISSUE_PREFIX + "StringBoolean";
 
 	public static final String ISSUE__TYPE_CONSTRAINT_NOT_FULFILLED = ISSUE_PREFIX + "TypeConstraintNotFulfilled";

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
@@ -168,6 +168,11 @@ public interface IValidationAdvisor extends IPotentialProblemsAdvisor {
 	public boolean allowSeparatorExpression();
 
 	/**
+	 * The 3.7 --parser future allows splash attributes in resource body
+	 */
+	public boolean allowSplashAttribute();
+
+	/**
 	 * @return wether or not type definitions are allowed (introduced in Puppet 4.x)
 	 */
 	public boolean allowTypeDefinitions();

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -226,6 +226,14 @@ public class ValidationAdvisor {
 			return false;
 		}
 
+		/**
+		 * @returns false
+		 */
+		@Override
+		public boolean allowSplashAttribute() {
+			return false;
+		}
+
 		@Override
 		public boolean allowTypeDefinitions() {
 			return false;
@@ -475,6 +483,11 @@ public class ValidationAdvisor {
 
 		@Override
 		public boolean allowSeparatorExpression() {
+			return true;
+		}
+
+		@Override
+		public boolean allowSplashAttribute() {
 			return true;
 		}
 


### PR DESCRIPTION
Ensure that '*' can be used as an attribute name, but only if
target platform >= 4.0. Also check that LHS of attribute is either
dynamic or a literal hash.

This PR extends from the issue-172 branch to avoid merge conflicts.
