### PR TITLE
(GEP-386) Validate that mode attributes are strings

### DIFF
--- a/com.puppetlabs.geppetto.graph.tests/testData/test-modules/common/manifests/defines/file2augeas.pp
+++ b/com.puppetlabs.geppetto.graph.tests/testData/test-modules/common/manifests/defines/file2augeas.pp
@@ -15,7 +15,7 @@ $filesc = regsubst($file,'[/]','_','G')
 
     file {
         "$basedir/augeas$filesc-$parameter":
-            mode => 600, owner => root, group => root,
+            mode => 0600, owner => root, group => root,
             path => "$basedir/augeas$filesc-$parameter",
             content => template("common/augeasconfig.erb"),
             notify  => Exec["Augeas_$basedir/augeas$file-$parameter"],

--- a/com.puppetlabs.geppetto.graph.tests/testData/test-modules/test-module/manifests/init.pp
+++ b/com.puppetlabs.geppetto.graph.tests/testData/test-modules/test-module/manifests/init.pp
@@ -32,7 +32,7 @@ class test-module {
 	}
 
 	file { "/etc/java_release":
-		owner => root, group => root, mode => 440,
+		owner => root, group => root, mode => '440',
 		content => $java_release_content,
 		ensure => present,
 		require => $java_requirement

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferenceConstants.java
@@ -27,6 +27,8 @@ public class PPPreferenceConstants {
 
 	public static final String PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED = "assignmentToVarNamedTrusted";
 
+	public static final String PROBLEM_ATTRIBUTE_IS_NOT_STRING = "attributeIsNotString";
+
 	public static final String PROBLEM_BOOLEAN_STRING = "booleanString";
 
 	public static final String PROBLEM_CASE_DEFAULT_LAST = "CaseDefaultLast";

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPPreferencesHelper.java
@@ -70,30 +70,33 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 	 * Add all preference that requires a rebuild when their value change.
 	 */
 	private final List<String> requiresRebuild = Lists.newArrayList(//
-		PPPreferenceConstants.PUPPET_TARGET_VERSION, //
-		PPPreferenceConstants.PUPPET_ENVIRONMENT, //
-		PPPreferenceConstants.PUPPET_PROJECT_PATH, //
-		PPPreferenceConstants.PUPPET_MANIFEST_DIR, //
-		PPPreferenceConstants.PUPPET_FOLDER_FILTER, //
-		PPPreferenceConstants.PROBLEM_INTERPOLATED_HYPHEN, //
-		PPPreferenceConstants.PROBLEM_BOOLEAN_STRING, //
-		PPPreferenceConstants.PROBLEM_MISSING_DEFAULT, //
-		PPPreferenceConstants.PROBLEM_CASE_DEFAULT_LAST, //
-		PPPreferenceConstants.PROBLEM_SELECTOR_DEFAULT_LAST, //
-
-		PPPreferenceConstants.PROBLEM_UNQUOTED_RESOURCE_TITLE, //
-		PPPreferenceConstants.PROBLEM_DQ_STRING_NOT_REQUIRED, //
-		PPPreferenceConstants.PROBLEM_DQ_STRING_NOT_REQUIRED_VAR, //
-		PPPreferenceConstants.PROBLEM_UNBRACED_INTERPOLATION, //
-		PPPreferenceConstants.PROBLEM_ML_COMMENTS, //
-		PPPreferenceConstants.PROBLEM_RTOL_RELATIONSHIP, //
-		PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_STRING, //
-		PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED, //
-		PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST, //
-		PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, //
-		PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT, //
-		PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, //
-		PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS, PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE //
+		// @fmtOff
+		PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_STRING,
+		PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED,
+		PPPreferenceConstants.PROBLEM_ATTRIBUTE_IS_NOT_STRING,
+		PPPreferenceConstants.PROBLEM_BOOLEAN_STRING,
+		PPPreferenceConstants.PROBLEM_CASE_DEFAULT_LAST,
+		PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT,
+		PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE,
+		PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS,
+		PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME,
+		PPPreferenceConstants.PROBLEM_DQ_STRING_NOT_REQUIRED,
+		PPPreferenceConstants.PROBLEM_DQ_STRING_NOT_REQUIRED_VAR,
+		PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST,
+		PPPreferenceConstants.PROBLEM_INTERPOLATED_HYPHEN,
+		PPPreferenceConstants.PROBLEM_MISSING_DEFAULT,
+		PPPreferenceConstants.PROBLEM_ML_COMMENTS,
+		PPPreferenceConstants.PROBLEM_RTOL_RELATIONSHIP,
+		PPPreferenceConstants.PROBLEM_SELECTOR_DEFAULT_LAST,
+		PPPreferenceConstants.PROBLEM_UNQUOTED_RESOURCE_TITLE,
+		PPPreferenceConstants.PROBLEM_UNBRACED_INTERPOLATION,
+		PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME,
+		PPPreferenceConstants.PUPPET_ENVIRONMENT,
+		PPPreferenceConstants.PUPPET_FOLDER_FILTER,
+		PPPreferenceConstants.PUPPET_MANIFEST_DIR,
+		PPPreferenceConstants.PUPPET_PROJECT_PATH,
+		PPPreferenceConstants.PUPPET_TARGET_VERSION
+		// @fmtOn
 	);
 
 	private IPreferenceStoreAccess preferenceStoreAccess;
@@ -126,6 +129,10 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 
 	public ValidationPreference getAssignmentToVariableNamedTrusted() {
 		return getPreference(PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED);
+	}
+
+	public ValidationPreference getAttributeIsNotString() {
+		return getPreference(PPPreferenceConstants.PROBLEM_ATTRIBUTE_IS_NOT_STRING);
 	}
 
 	public ValidationPreference getBooleansInStringForm() {
@@ -287,36 +294,34 @@ public class PPPreferencesHelper implements IPreferenceStoreInitializer, IProper
 		store = preferenceStoreAccess.getWritablePreferenceStore();
 		store.setDefault(PPPreferenceConstants.AUTO_EDIT_STRATEGY, 0);
 		store.setDefault(PPPreferenceConstants.AUTO_EDIT_COMPLETE_COMPOUND_BLOCKS, true);
+
 		store.setDefault(PPPreferenceConstants.PUPPET_TARGET_VERSION, PuppetTarget.getDefault().getLiteral());
 		store.setDefault(PPPreferenceConstants.PUPPET_PROJECT_PATH, PPSearchPath.DEFAULT_PUPPET_PROJECT_PATH);
 		store.setDefault(PPPreferenceConstants.PUPPET_MANIFEST_DIR, PPSearchPath.DEFAULT_MANIFEST_DIR);
 		store.setDefault(PPPreferenceConstants.PUPPET_FOLDER_FILTER, defaultFolderFilter);
 		store.setDefault(PPPreferenceConstants.PUPPET_ENVIRONMENT, PPSearchPath.DEFAULT_PUPPET_ENVIRONMENT);
 
-		store.setDefault(PPPreferenceConstants.PROBLEM_INTERPOLATED_HYPHEN, ValidationPreference.WARNING.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_BOOLEAN_STRING, ValidationPreference.WARNING.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_MISSING_DEFAULT, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_STRING, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_ASSIGNMENT_TO_VAR_NAMED_TRUSTED, ValidationPreference.WARNING.toString());
-
-		// stylistic
+		store.setDefault(PPPreferenceConstants.PROBLEM_ATTRIBUTE_IS_NOT_STRING, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_BOOLEAN_STRING, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_CASE_DEFAULT_LAST, ValidationPreference.IGNORE.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_SELECTOR_DEFAULT_LAST, ValidationPreference.IGNORE.toString());
-
-		store.setDefault(PPPreferenceConstants.PROBLEM_UNQUOTED_RESOURCE_TITLE, ValidationPreference.IGNORE.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_DQ_STRING_NOT_REQUIRED, ValidationPreference.IGNORE.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_DQ_STRING_NOT_REQUIRED_VAR, ValidationPreference.IGNORE.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_UNBRACED_INTERPOLATION, ValidationPreference.IGNORE.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST, ValidationPreference.IGNORE.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_INTERPOLATED_HYPHEN, ValidationPreference.WARNING.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_MISSING_DEFAULT, ValidationPreference.WARNING.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_ML_COMMENTS, ValidationPreference.IGNORE.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_RTOL_RELATIONSHIP, ValidationPreference.IGNORE.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_ENSURE_NOT_FIRST, ValidationPreference.IGNORE.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_SELECTOR_DEFAULT_LAST, ValidationPreference.IGNORE.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_UNQUOTED_RESOURCE_TITLE, ValidationPreference.IGNORE.toString());
+		store.setDefault(PPPreferenceConstants.PROBLEM_UNBRACED_INTERPOLATION, ValidationPreference.IGNORE.toString());
 		store.setDefault(PPPreferenceConstants.PROBLEM_VALIDITY_ASSERTED_AT_RUNTIME, ValidationPreference.IGNORE.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_IMPORT, ValidationPreference.WARNING.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_VARIABLE_NAME, ValidationPreference.WARNING.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_PLUS_EQUALS, ValidationPreference.WARNING.toString());
-		store.setDefault(PPPreferenceConstants.PROBLEM_DEPRECATED_NODE_INHERITANCE, ValidationPreference.WARNING.toString());
 
-		// save actions
 		store.setDefault(PPPreferenceConstants.SAVE_ACTION_ENSURE_ENDS_WITH_NL, false);
 		store.setDefault(PPPreferenceConstants.SAVE_ACTION_TRIM_LINES, false);
 		store.setDefault(PPPreferenceConstants.SAVE_ACTION_REPLACE_FUNKY_SPACES, false);

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPStylisticProblemsPreferencePage.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/preferences/PPStylisticProblemsPreferencePage.java
@@ -20,6 +20,8 @@ public class PPStylisticProblemsPreferencePage extends AbstractPreferencePage {
 
 	@Override
 	protected void createFieldEditors() {
+		addField(new ValidationPreferenceFieldEditor(
+			PPPreferenceConstants.PROBLEM_ATTRIBUTE_IS_NOT_STRING, "File mode attribute is not in string form", getFieldEditorParent()));
 
 		// case and selector
 		this.addField(new ValidationPreferenceFieldEditor(

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/quickfix/PPQuickfixProvider.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/quickfix/PPQuickfixProvider.java
@@ -162,6 +162,31 @@ public class PPQuickfixProvider extends DefaultQuickfixProvider {
 		});
 	}
 
+	@Fix(IPPDiagnostics.ISSUE__NOT_OCTAL_NUMBER)
+	public void changeNumberToOctalString(final Issue issue, final IssueResolutionAcceptor acceptor) {
+		changeNumberToOctalString2(issue, acceptor);
+	}
+
+	@Fix(IPPDiagnostics.ISSUE__OCTAL_SHOULD_BE_STRING)
+	public void changeNumberToOctalString2(final Issue issue, final IssueResolutionAcceptor acceptor) {
+		final IModificationContext modificationContext = getModificationContextFactory().createModificationContext(issue);
+		final IXtextDocument xtextDocument = modificationContext.getXtextDocument();
+		xtextDocument.readOnly(new IUnitOfWork.Void<XtextResource>() {
+			@Override
+			public void process(XtextResource state) throws Exception {
+
+				String issueString = xtextDocument.get(issue.getOffset(), issue.getLength());
+				String pfx = issueString.startsWith("0")
+					? "'"
+					: "'0";
+
+				acceptor.accept(issue, "Convert numeric value to string", //
+					"Changes " + issueString + " to " + pfx + issueString + '\'', null, //
+					new SurroundWithTextModification(issue.getOffset(), issueString.length(), pfx, "'"));
+			}
+		});
+	}
+
 	@Fix(IPPDiagnostics.ISSUE__UNBRACED_INTERPOLATION)
 	public void changeToBracedInterpolation(final Issue issue, final IssueResolutionAcceptor acceptor) {
 		final IModificationContext modificationContext = getModificationContextFactory().createModificationContext(issue);

--- a/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl.ui/src/com/puppetlabs/geppetto/pp/dsl/ui/validation/PreferenceBasedPotentialProblemsAdvisor.java
@@ -40,6 +40,11 @@ public class PreferenceBasedPotentialProblemsAdvisor implements IPotentialProble
 	}
 
 	@Override
+	public ValidationPreference attributeIsNotString() {
+		return preferences.getAttributeIsNotString();
+	}
+
+	@Override
 	public ValidationPreference booleansInStringForm() {
 		return preferences.getBooleansInStringForm();
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/DefaultPotentialProblemsAdvisor.java
@@ -27,6 +27,11 @@ public class DefaultPotentialProblemsAdvisor implements IPotentialProblemsAdviso
 	}
 
 	@Override
+	public ValidationPreference attributeIsNotString() {
+		return ValidationPreference.WARNING;
+	}
+
+	@Override
 	public ValidationPreference booleansInStringForm() {
 		return ValidationPreference.WARNING;
 	}

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IPPDiagnostics.java
@@ -109,6 +109,8 @@ public interface IPPDiagnostics {
 
 	public static final String ISSUE__NOT_NUMERIC = ISSUE_PREFIX + "NotNumeric";
 
+	public static final String ISSUE__NOT_OCTAL_NUMBER = ISSUE_PREFIX + "NotOctalNumber";
+
 	public static final String ISSUE__NOT_ON_PATH = ISSUE_PREFIX + "NotOnPath";
 
 	public static final String ISSUE__NOT_REGEX = ISSUE_PREFIX + "Badlyformedregularexpression";
@@ -124,6 +126,8 @@ public interface IPPDiagnostics {
 	public static final String ISSUE__NOT_VARNAME = ISSUE_PREFIX + "NotVariableName";
 
 	public static final String ISSUE__NULL_EXPRESSION = ISSUE_PREFIX + "NullExpression";
+
+	public static final String ISSUE__OCTAL_SHOULD_BE_STRING = ISSUE_PREFIX + "OctalShouldBeString";
 
 	public static final String ISSUE__PARAM_DEFAULT_NOT_LAST = ISSUE_PREFIX + "ParamDefaultNotLast";
 

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IStylisticProblemsAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IStylisticProblemsAdvisor.java
@@ -17,20 +17,23 @@ public interface IStylisticProblemsAdvisor {
 
 	/**
 	 * How an (optional) default that is not placed last should be validated for a case expression.
-	 *
-	 * @return
 	 */
-	public ValidationPreference caseDefaultShouldAppearLast();
+	ValidationPreference caseDefaultShouldAppearLast();
 
 	/**
 	 * How the 'ensure' property should be validated if not placed first among a resource's properties.
 	 */
-	public ValidationPreference ensureShouldAppearFirstInResource();
+	ValidationPreference ensureShouldAppearFirstInResource();
 
 	/**
 	 * How to 'validate' the presence of ML comments.
 	 */
-	public ValidationPreference mlComments();
+	ValidationPreference mlComments();
+
+	/**
+	 * Octal number is not quoted
+	 */
+	ValidationPreference attributeIsNotString();
 
 	/**
 	 * How to validate right to left relationships ( e.g. a <- b and a <~ b)
@@ -39,9 +42,7 @@ public interface IStylisticProblemsAdvisor {
 
 	/**
 	 * How an (almost required) default that is not placed last should be validated for a selector expression.
-	 *
-	 * @return
 	 */
-	public ValidationPreference selectorDefaultShouldAppearLast();
+	ValidationPreference selectorDefaultShouldAppearLast();
 
 }

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/IValidationAdvisor.java
@@ -25,7 +25,7 @@ import com.puppetlabs.geppetto.pp.dsl.validation.ValidationAdvisor.ValidationAdv
  * to a language version.
  */
 public interface IValidationAdvisor extends IPotentialProblemsAdvisor {
-	public enum ComplianceLevel {
+	enum ComplianceLevel {
 		PUPPET_2_6("2.6") {
 			@Override
 			public IValidationAdvisor createValidationAdvisor(IPotentialProblemsAdvisor problemsAdvisor) {
@@ -98,139 +98,145 @@ public interface IValidationAdvisor extends IPotentialProblemsAdvisor {
 	/**
 	 * The 3.5 --parser future allows any value as hash key
 	 */
-	public boolean allowAnyValueAsHashKey();
+	boolean allowAnyValueAsHashKey();
 
 	/**
 	 * The 3.5 --parser future allows chained assignments
 	 */
-	public boolean allowChainedAssignments();
+	boolean allowChainedAssignments();
 
 	/**
 	 * The 3.2 --parser future allows blocks to end with an expression
 	 */
-	public boolean allowExpressionLastInBlocks();
+	boolean allowExpressionLastInBlocks();
 
 	/**
 	 * If 3.0 extended dependency types should be allowed
 	 * (resource | resourceref | collection | variable | quoted text | selector | case statement | hasharrayaccesses)
 	 * See geppetto Issue #400.
 	 */
-	public boolean allowExtendedDependencyTypes();
+	boolean allowExtendedDependencyTypes();
 
 	/**
 	 * If 3.5 extended match RHS expressions (string, type, or variables) should be allowed.
 	 * See issue GEP-110
 	 */
-	public boolean allowExtendedMatchRHS();
+	boolean allowExtendedMatchRHS();
+
+	/**
+	 * The 3.7 --parser future allows a title that is literal default in resource body
+	 */
+	boolean allowExtendedTitleExpressions();
 
 	/**
 	 * Should Hash be allowed in a selector.
 	 * Puppet issue #5516
 	 */
-	public boolean allowHashInSelector();
+	boolean allowHashInSelector();
 
 	/**
 	 * Before 3.0 and hiera support, a class can not inherit from a parameterized class.
 	 */
-	public boolean allowInheritanceFromParameterizedClass();
+	boolean allowInheritanceFromParameterizedClass();
 
 	/**
 	 * If lambdas are allowed or not
 	 */
-	public boolean allowLambdas();
+	boolean allowLambdas();
 
 	/**
-	 * The 3.7 --parser future allows a title that is literal default in resource body
+	 * Starting with 4.0, integer literals are parsed as such which means that a decimal
+	 * mode will be interpreted as decimal, not octal.
 	 */
-	public boolean allowExtendedTitleExpressions();
+	boolean allowModeWithNonOctalIntegerLiterals();
 
 	/**
 	 * Before 3.2 modulo operator '%' was not supported.
 	 *
 	 * @return
 	 */
-	public boolean allowModulo();
+	boolean allowModulo();
 
 	/**
 	 * Should more than 2 at (i.e. []) operators be allowed in sequence e.g. $a[x][y][z]
 	 * Puppet issue #6269
 	 */
-	public boolean allowMoreThan2AtInSequence();
+	boolean allowMoreThan2AtInSequence();
 
 	/**
 	 * The 3.5 with --parser future should allow the expressions if, unless, and case as r-values.
 	 */
-	public boolean allowRHSConditionals();
+	boolean allowRHSConditionals();
 
 	/**
 	 * 3.2 --parser future adds an expression separator (';')
 	 */
-	public boolean allowSeparatorExpression();
+	boolean allowSeparatorExpression();
 
 	/**
 	 * The 3.7 --parser future allows splash attributes in resource body
 	 */
-	public boolean allowSplashAttribute();
+	boolean allowSplashAttribute();
 
 	/**
 	 * @return wether or not type definitions are allowed (introduced in Puppet 4.x)
 	 */
-	public boolean allowTypeDefinitions();
+	boolean allowTypeDefinitions();
 
 	/**
 	 * The "unless" statement was added in Puppet 3.0.
 	 *
 	 * @return
 	 */
-	public boolean allowUnless();
+	boolean allowUnless();
 
 	/**
 	 * The 3.2 --parser future allows unless to have an else (but not ifelse)
 	 */
-	public boolean allowUnlessElse();
+	boolean allowUnlessElse();
 
 	/**
 	 * Prior to 2.7 it was not possible to use unquoted qualified resource names.
 	 *
 	 * @return
 	 */
-	public boolean allowUnquotedQualifiedResourceNames();
+	boolean allowUnquotedQualifiedResourceNames();
 
 	/**
 	 * Prior to version 2.7.8, an optional end comma in a definition argument list causes parse exception.
 	 *
 	 * @return
 	 */
-	public ValidationPreference definitionArgumentListEndComma();
+	ValidationPreference definitionArgumentListEndComma();
 
 	/**
 	 * Prior to 3.0, a missing $ in a definition parameter name declaration was deprecated.
 	 * In 3.0 it is an error.
 	 */
-	public ValidationPreference definitionParamterMissingDollar();
+	ValidationPreference definitionParamterMissingDollar();
 
 	/**
 	 * Hyphens in names are deprecated
 	 * Puppet issue #10146
 	 * And will be errors in later releases.
 	 */
-	public ValidationPreference hyphensInNames();
+	ValidationPreference hyphensInNames();
 
 	/**
 	 * Prior to 2.7 (?) it was not possible to have case labels with a ".".
 	 *
 	 * @return
 	 */
-	public ValidationPreference periodInCase();
+	ValidationPreference periodInCase();
 
 	/**
 	 * How should relationships goign right to left be reported.
 	 */
 	@Override
-	public ValidationPreference rightToLeftRelationships();
+	ValidationPreference rightToLeftRelationships();
 
 	/**
 	 * How should unqualified variable references be reported (ignore, warning, error).
 	 */
-	public ValidationPreference unqualifiedVariables();
+	ValidationPreference unqualifiedVariables();
 }

--- a/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
+++ b/com.puppetlabs.geppetto.pp.dsl/src/com/puppetlabs/geppetto/pp/dsl/validation/ValidationAdvisor.java
@@ -31,6 +31,11 @@ public class ValidationAdvisor {
 		}
 
 		@Override
+		public ValidationPreference attributeIsNotString() {
+			return problemsAdvisor.attributeIsNotString();
+		}
+
+		@Override
 		public ValidationPreference booleansInStringForm() {
 			return problemsAdvisor.booleansInStringForm();
 		}
@@ -168,6 +173,14 @@ public class ValidationAdvisor {
 		}
 
 		/**
+		 * @returns false
+		 */
+		@Override
+		public boolean allowExtendedTitleExpressions() {
+			return false;
+		}
+
+		/**
 		 * @returns true
 		 */
 		@Override
@@ -191,12 +204,9 @@ public class ValidationAdvisor {
 			return false;
 		}
 
-		/**
-		 * @returns false
-		 */
 		@Override
-		public boolean allowExtendedTitleExpressions() {
-			return false;
+		public boolean allowModeWithNonOctalIntegerLiterals() {
+			return true; // Always parsed as a string by Puppet so OK
 		}
 
 		/**
@@ -472,13 +482,18 @@ public class ValidationAdvisor {
 		}
 
 		@Override
+		public boolean allowExtendedTitleExpressions() {
+			return true;
+		}
+
+		@Override
 		public boolean allowLambdas() {
 			return true;
 		}
 
 		@Override
-		public boolean allowExtendedTitleExpressions() {
-			return true;
+		public boolean allowModeWithNonOctalIntegerLiterals() {
+			return false; // Parsed as a integer by Puppet >= 4.0 so this is not OK
 		}
 
 		@Override

--- a/com.puppetlabs.geppetto.pp/model/PP.genmodel
+++ b/com.puppetlabs.geppetto.pp/model/PP.genmodel
@@ -35,7 +35,6 @@
     <genClasses ecoreClass="PP.ecore#//Definition">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute PP.ecore#//Definition/className"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//Definition/arguments"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//Definition/statements"/>
     </genClasses>
     <genClasses ecoreClass="PP.ecore#//DefinitionArgumentList">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//DefinitionArgumentList/arguments"/>
@@ -51,12 +50,10 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//CaseExpression/cases"/>
     </genClasses>
     <genClasses ecoreClass="PP.ecore#//Case">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//Case/statements"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//Case/values"/>
     </genClasses>
     <genClasses ecoreClass="PP.ecore#//IfExpression">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//IfExpression/condExpr"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//IfExpression/thenStatements"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//IfExpression/elseStatement"/>
     </genClasses>
     <genClasses ecoreClass="PP.ecore#//LiteralExpression"/>
@@ -129,7 +126,6 @@
     <genClasses ecoreClass="PP.ecore#//NodeDefinition">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//NodeDefinition/hostNames"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//NodeDefinition/parentName"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//NodeDefinition/statements"/>
     </genClasses>
     <genClasses image="false" ecoreClass="PP.ecore#//UnaryExpression">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//UnaryExpression/expr"/>
@@ -178,7 +174,6 @@
     <genClasses ecoreClass="PP.ecore#//LiteralClass"/>
     <genClasses ecoreClass="PP.ecore#//UnlessExpression">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//UnlessExpression/condExpr"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//UnlessExpression/thenStatements"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference PP.ecore#//UnlessExpression/elseStatement"/>
     </genClasses>
     <genClasses image="false" ecoreClass="PP.ecore#//Lambda">

--- a/com.puppetlabs.geppetto.validation.tests/src/test/java/com/puppetlabs/geppetto/validation/tests/TestValidatorService.java
+++ b/com.puppetlabs.geppetto.validation.tests/src/test/java/com/puppetlabs/geppetto/validation/tests/TestValidatorService.java
@@ -119,6 +119,7 @@ public class TestValidatorService extends AbstractValidationTest {
 			asserter.issue(IPPDiagnostics.ISSUE__UNKNOWN_VARIABLE), //
 			asserter.issue(IPPDiagnostics.ISSUE__HYPHEN_IN_NAME), //
 			asserter.messageFragment("unexpected tIDENTIFIER"));
+		asserter.assertWarnings(asserter.issue(IPPDiagnostics.ISSUE__OCTAL_SHOULD_BE_STRING));
 	}
 
 	@Test

--- a/com.puppetlabs.geppetto.validation.tests/testData/test-modules/test-module/manifests/init.pp
+++ b/com.puppetlabs.geppetto.validation.tests/testData/test-modules/test-module/manifests/init.pp
@@ -32,7 +32,7 @@ class test_module {
 	}
 
 	file { "/etc/java_release":
-		owner => root, group => root, mode => 440,
+		owner => root, group => root, mode => '440',
 		content => $java_release_content,
 		ensure => present,
 		require => $java_requirement


### PR DESCRIPTION
This commit introduces two new issues. The first one  isfor cases
where a non-octal integer literal is used as a file mode. This issue
is only relevant in versions >= 4.0 and the condition will always be
reported as an error. The second is a stylistic issue for the case
where an integer literal is used the mode attribute. It's motivated
by the style guide that recommends that this value should be a
string in all cases.

A quick fix is added for both problems. It converts the value to
a single quoted string and adds a leading zero if that is missing.

The stylistic issue can be controlled with a settable preference. The
default value setting is WARNING.
