### PR TITLE
Update navigation's link to the introduction.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,7 +91,7 @@ $(document).ready(function() {
             <h2>DOCUMENTATION</h2>
         </div>
             <ul>
-                <li><a href="http://docs.puppetlabs.com/geppetto/latest/index.html">Introduction to Geppetto</a></li>
+                <li><a href="https://github.com/puppetlabs/geppetto/blob/dev/docs/4.2/index.md">Introduction to Geppetto</a></li>
             </ul>
         <div class="title">
             <h2>LICENSE</h2>


### PR DESCRIPTION
Unless we have a better way to point to this or would rather render that file using the Geppetto gh-pages templates.
